### PR TITLE
Fix typos

### DIFF
--- a/cmd/nats-service-example/main.go
+++ b/cmd/nats-service-example/main.go
@@ -17,7 +17,7 @@ func getTime(msg *nats_service.NatsMessage) *nats_service.NatsServiceError {
 	paramOne := msg.Parameters["parameterOne"]
 	paramTwo := msg.Parameters["parameterTwo"]
 
-	log.Printf("paramterOne: %s parameterTwo: %s", paramOne, paramTwo)
+	log.Printf("parameterOne: %s parameterTwo: %s", paramOne, paramTwo)
 
 	s := fmt.Sprintf("The time is %s", time.Now())
 
@@ -66,7 +66,7 @@ func main() {
 		if err != nil {
 			log.Printf("Error: Shutdown failed, %v", err)
 		} else {
-			log.Printf("Shutdown Succesfull, yea!")
+			log.Printf("Shutdown Successful, yeah!")
 			os.Exit(0)
 		}
 	}()

--- a/cmd/requester-example/main.go
+++ b/cmd/requester-example/main.go
@@ -14,7 +14,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	exampleWithOutExceptions(client)
+	exampleWithoutExceptions(client)
 	//
 	exampleWithExceptions(client)
 	////
@@ -22,7 +22,7 @@ func main() {
 	exampleLargeBodyTestCompression(client)
 }
 
-func exampleWithOutExceptions(client *nats_service_client.Client) {
+func exampleWithoutExceptions(client *nats_service_client.Client) {
 	rspMsg, svcErr, err := client.DoRequest("id13213", "rx.api.getTime", nil, nil, time.Second*10)
 
 	//	error connecting to service


### PR DESCRIPTION
## Summary
- fix parameterOne log typo in nats-service-example
- fix shutdown message
- rename `exampleWithOutExceptions` to `exampleWithoutExceptions`

## Testing
- `go vet ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*
- `go build ./...` *(fails: no route to host)*