### PR TITLE
Add response documentation support to endpoint discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ cd cmd/requester-example && NATS_URL=nats://localhost:4222 go run main.go
 - Endpoints are matched by regex against incoming NATS subjects
 - Path separator can be `.` or `/` (detected automatically)
 - Parameters extracted via regex named groups
-- Use `AddEndpointWithDoc(path, desc, headers, params, handler)` to include documentation for discovery
+- Use `AddEndpointWithDoc(path, desc, headers, params, response, handler)` to include documentation for discovery
 - Use `AddEndpointWithDocs()` for batch registration with documentation
 - Parameter names are auto-discovered from path; user docs add descriptions/examples
 
@@ -217,15 +217,16 @@ nats-discover -s nats://localhost:4222 --timeout 5s
 
 ### Registering Endpoints with Documentation
 ```go
-// Single endpoint with description (pass nil for headers/params if not needed)
-err := service.AddEndpointWithDoc("users.:userId", "Get user by ID", nil, nil, userHandler)
+// Single endpoint with description (pass nil for headers/params/response if not needed)
+err := service.AddEndpointWithDoc("users.:userId", "Get user by ID", nil, nil, nil, userHandler)
 
-// Single endpoint with full documentation
+// Single endpoint with full documentation including response
 err := service.AddEndpointWithDoc(
     "orders.:orderId",
     "Get order by ID",
     []nats_service.HeaderDoc{{Name: "Authorization", Required: true}},
     []nats_service.ParameterDoc{{Name: "orderId", Description: "Order ID", Required: true}},
+    &nats_service.ResponseDoc{Description: "Order details", ContentType: "application/json"},
     orderHandler,
 )
 
@@ -238,6 +239,7 @@ endpoints := []nats_service.EndpointRegistration{
         Parameters: []nats_service.ParameterDoc{
             {Name: "userId", Description: "User identifier", Required: true},
         },
+        Response: &nats_service.ResponseDoc{Description: "User object"},
         Handler: userHandler,
     },
 }

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ service.AddEndpoint("ping", pingHandler)
 ### Single Endpoint with Documentation
 
 ```go
-// Endpoint with full documentation
+// Endpoint with full documentation including response
 service.AddEndpointWithDoc(
     "orders.:orderId",
     "Get order by ID",
@@ -168,6 +168,11 @@ service.AddEndpointWithDoc(
     },
     []nats_service.ParameterDoc{
         {Name: "orderId", Description: "Order identifier", Required: true, Example: "ORD-456"},
+    },
+    &nats_service.ResponseDoc{
+        Description: "Order details in JSON format",
+        ContentType: "application/json",
+        Example:     `{"id": "ORD-456", "status": "pending"}`,
     },
     getOrderHandler,
 )
@@ -180,6 +185,7 @@ endpoints := []nats_service.EndpointRegistration{
     {
         Path:        "health",
         Description: "Health check endpoint",
+        Response:    &nats_service.ResponseDoc{Description: "OK", ContentType: "text/plain"},
         Handler:     healthHandler,
     },
     {
@@ -190,6 +196,10 @@ endpoints := []nats_service.EndpointRegistration{
         },
         Parameters: []nats_service.ParameterDoc{
             {Name: "orderId", Description: "Order ID", Required: true, Example: "ORD-123"},
+        },
+        Response: &nats_service.ResponseDoc{
+            Description: "Order details",
+            ContentType: "application/json",
         },
         Handler: getOrderHandler,
     },
@@ -287,15 +297,18 @@ nats-discover -s nats://localhost:4222 --format yaml
 SERVICE     SUBJECT PATTERN                  EXAMPLE                         DESCRIPTION
 -------     ---------------                  -------                         -----------
 myapp.api   myapp.api.health                 -                               Health check endpoint
+              Response: text/plain - OK
 myapp.api   myapp.api.orders.:orderId        myapp.api.orders.ORD-123        Get order by ID
               Params: orderId* (Order identifier)
               Headers: Authorization*
+              Response: application/json - Order details
 ```
 
 The output shows:
 - **SUBJECT PATTERN**: The NATS subject with `:param` placeholders
 - **EXAMPLE**: A concrete example showing the actual subject to call
 - **Params/Headers**: Documentation for parameters and headers (`*` = required)
+- **Response**: Content type and description of what the endpoint returns
 
 See [docs/endpoint-discovery.md](docs/endpoint-discovery.md) for complete documentation.
 

--- a/cmd/nats-discover/main.go
+++ b/cmd/nats-discover/main.go
@@ -403,6 +403,18 @@ func outputYAML(responses []nats_service.DiscoveryResponse) error {
 					}
 				}
 			}
+			if ep.Response != nil {
+				fmt.Println("    response:")
+				if ep.Response.Description != "" {
+					fmt.Printf("      description: %s\n", ep.Response.Description)
+				}
+				if ep.Response.ContentType != "" {
+					fmt.Printf("      contentType: %s\n", ep.Response.ContentType)
+				}
+				if ep.Response.Example != "" {
+					fmt.Printf("      example: %s\n", ep.Response.Example)
+				}
+			}
 			if ep.Description != "" {
 				fmt.Printf("    description: %s\n", ep.Description)
 			}
@@ -434,8 +446,8 @@ func outputTable(responses []nats_service.DiscoveryResponse) error {
 
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", resp.ServiceName, ep.FullSubject, example, desc)
 
-			// Show parameters and headers on separate lines if present
-			if len(ep.Parameters) > 0 || len(ep.Headers) > 0 {
+			// Show parameters, headers, and response on separate lines if present
+			if len(ep.Parameters) > 0 || len(ep.Headers) > 0 || ep.Response != nil {
 				// Parameters
 				if len(ep.Parameters) > 0 {
 					paramDetails := make([]string, 0, len(ep.Parameters))
@@ -463,6 +475,23 @@ func outputTable(responses []nats_service.DiscoveryResponse) error {
 						headerDetails = append(headerDetails, detail)
 					}
 					fmt.Fprintf(w, "\t  Headers: %s\t\t\n", strings.Join(headerDetails, ", "))
+				}
+
+				// Response
+				if ep.Response != nil {
+					responseDetail := ""
+					if ep.Response.ContentType != "" {
+						responseDetail = ep.Response.ContentType
+					}
+					if ep.Response.Description != "" {
+						if responseDetail != "" {
+							responseDetail += " - "
+						}
+						responseDetail += ep.Response.Description
+					}
+					if responseDetail != "" {
+						fmt.Fprintf(w, "\t  Response: %s\t\t\n", responseDetail)
+					}
 				}
 			}
 		}

--- a/docs/endpoint-discovery.md
+++ b/docs/endpoint-discovery.md
@@ -13,6 +13,7 @@ When a service starts, it automatically registers itself on the `_discovery.all`
 - **Deduplication**: Multiple instances of the same service are deduplicated by endpoint full subject
 - **Header Documentation**: Document required and optional headers for each endpoint
 - **Parameter Extraction**: Path parameters (`:param` syntax) are automatically extracted and displayed
+- **Response Documentation**: Document what each endpoint returns (content type, description, example)
 - **Wildcard Detection**: Single (`*`) and multi (`>`) wildcards are detected and labeled
 
 ## Documenting Your Endpoints
@@ -27,9 +28,9 @@ service.AddEndpoint("health", healthHandler)
 
 ```go
 // Simple endpoint with just a description
-service.AddEndpointWithDoc("health", "Health check endpoint", nil, nil, healthHandler)
+service.AddEndpointWithDoc("health", "Health check endpoint", nil, nil, nil, healthHandler)
 
-// Endpoint with headers and parameter documentation
+// Endpoint with headers, parameter, and response documentation
 service.AddEndpointWithDoc(
     "orders.:orderId",
     "Get order by ID",
@@ -38,6 +39,11 @@ service.AddEndpointWithDoc(
     },
     []nats_service.ParameterDoc{
         {Name: "orderId", Description: "Unique order identifier", Required: true, Example: "ORD-12345"},
+    },
+    &nats_service.ResponseDoc{
+        Description: "Order details in JSON format",
+        ContentType: "application/json",
+        Example:     `{"id": "ORD-12345", "status": "shipped"}`,
     },
     getOrderHandler,
 )
@@ -50,6 +56,7 @@ endpoints := []nats_service.EndpointRegistration{
     {
         Path:        "health",
         Description: "Health check endpoint - returns service status",
+        Response:    &nats_service.ResponseDoc{Description: "OK if healthy", ContentType: "text/plain"},
         Handler:     healthHandler,
     },
     {
@@ -75,6 +82,11 @@ endpoints := []nats_service.EndpointRegistration{
                 Required:    true,
                 Example:     "ORD-12345",
             },
+        },
+        Response: &nats_service.ResponseDoc{
+            Description: "Order object with status and items",
+            ContentType: "application/json",
+            Example:     `{"id": "ORD-12345", "status": "shipped", "items": []}`,
         },
         Handler: getOrderHandler,
     },
@@ -107,6 +119,14 @@ err := service.AddEndpointWithDocs(endpoints)
 | Example     | string | Example value for documentation          |
 
 **Note:** Parameter names are automatically discovered from the endpoint path (e.g., `:orderId` extracts "orderId"). User-provided `ParameterDoc` entries are merged with auto-discovered names to add descriptions and examples.
+
+### ResponseDoc Fields
+
+| Field       | Type   | Description                              |
+|-------------|--------|------------------------------------------|
+| Description | string | What the endpoint returns                |
+| ContentType | string | MIME type (e.g., "application/json")     |
+| Example     | string | Example response payload                 |
 
 ## Using the nats-discover CLI
 
@@ -174,18 +194,22 @@ nats-discover -s nats://localhost:4222 --jwt "eyJ..." --seed "SUAM..."
 SERVICE     SUBJECT PATTERN                       EXAMPLE                              DESCRIPTION
 -------     ---------------                       -------                              -----------
 orders.api  orders.api.health                     -                                    Health check endpoint
+              Response: text/plain - OK if healthy
 orders.api  orders.api.orders.:orderId            orders.api.orders.ORD-12345          Get order by ID
               Params: orderId* (Unique order identifier)
               Headers: Authorization*, X-Request-ID
+              Response: application/json - Order object with status and items
 orders.api  orders.api.users.:userId.orders       orders.api.users.USR-98765.orders    Get all orders for a user
               Params: userId* (User identifier)
               Headers: Authorization*
+              Response: application/json - List of orders
 ```
 
 - **SUBJECT PATTERN**: The NATS subject with `:param` placeholders
 - **EXAMPLE**: A concrete example with parameters filled in (from `ParameterDoc.Example`)
 - Required parameters and headers are marked with `*`
 - Parameters without examples show `{paramName}` placeholder
+- Response shows content type and description when documented
 
 #### JSON
 
@@ -215,6 +239,11 @@ orders.api  orders.api.users.:userId.orders       orders.api.users.USR-98765.ord
             "example": "Bearer eyJhbG..."
           }
         ],
+        "response": {
+          "description": "Order object with status and items",
+          "contentType": "application/json",
+          "example": "{\"id\": \"ORD-12345\", \"status\": \"shipped\"}"
+        },
         "description": "Get order by ID"
       }
     ]
@@ -241,6 +270,10 @@ endpoints:
         description: Bearer token for authentication
         required: true
         example: Bearer eyJhbG...
+    response:
+      description: Order object with status and items
+      contentType: application/json
+      example: '{"id": "ORD-12345", "status": "shipped"}'
     description: Get order by ID
 ```
 
@@ -262,7 +295,11 @@ Services respond with a JSON payload:
     {
       "path": "health",
       "fullSubject": "orders.api.health",
-      "description": "Health check endpoint"
+      "description": "Health check endpoint",
+      "response": {
+        "description": "OK if healthy",
+        "contentType": "text/plain"
+      }
     },
     {
       "path": "orders.:orderId",
@@ -274,6 +311,11 @@ Services respond with a JSON payload:
       "headers": [
         {"name": "Authorization", "required": true}
       ],
+      "response": {
+        "description": "Order object",
+        "contentType": "application/json",
+        "example": "{\"id\": \"ORD-12345\", \"status\": \"shipped\"}"
+      },
       "description": "Get order by ID"
     }
   ]

--- a/pkg/nats-service/discovery.go
+++ b/pkg/nats-service/discovery.go
@@ -34,6 +34,13 @@ type ParameterDoc struct {
 	Example     string `json:"example,omitempty"`
 }
 
+// ResponseDoc represents documentation for an endpoint's response
+type ResponseDoc struct {
+	Description string `json:"description,omitempty"`
+	ContentType string `json:"contentType,omitempty"`
+	Example     string `json:"example,omitempty"`
+}
+
 // EndpointDoc represents documentation for a single endpoint
 type EndpointDoc struct {
 	Path           string         `json:"path"`
@@ -41,6 +48,7 @@ type EndpointDoc struct {
 	ExampleSubject string         `json:"exampleSubject,omitempty"`
 	Parameters     []ParameterDoc `json:"parameters,omitempty"`
 	Headers        []HeaderDoc    `json:"headers,omitempty"`
+	Response       *ResponseDoc   `json:"response,omitempty"`
 	Description    string         `json:"description,omitempty"`
 	WildcardType   string         `json:"wildcardType,omitempty"` // "single" (*) or "multi" (>)
 }
@@ -126,6 +134,11 @@ func (ns *NatService) buildEndpointDocs() []EndpointDoc {
 		// Include headers if provided
 		if len(ep.headers) > 0 {
 			doc.Headers = ep.headers
+		}
+
+		// Include response documentation if provided
+		if ep.response != nil {
+			doc.Response = ep.response
 		}
 
 		docs = append(docs, doc)

--- a/pkg/nats-service/integration_test.go
+++ b/pkg/nats-service/integration_test.go
@@ -287,7 +287,7 @@ func TestAddEndpointWithDoc(t *testing.T) {
 		return nil
 	}
 
-	err = natService.AddEndpointWithDoc("ping", "Health check endpoint", nil, nil, handler)
+	err = natService.AddEndpointWithDoc("ping", "Health check endpoint", nil, nil, nil, handler)
 	if err != nil {
 		t.Fatalf("Failed to add endpoint with doc: %v", err)
 	}

--- a/pkg/nats-service/nats-service.go
+++ b/pkg/nats-service/nats-service.go
@@ -57,6 +57,7 @@ type NatsEndpoint struct {
 	description      string
 	headers          []HeaderDoc
 	parameters       []ParameterDoc
+	response         *ResponseDoc
 }
 
 type NatsEndpointFunc func(msg *NatsMessage) *NatsServiceError
@@ -193,7 +194,7 @@ func (ns *NatService) AddEndpoint(path string, endPoint NatsEndpointFunc) error 
 // The description, headers, and parameters are included in discovery responses
 // to help clients understand the endpoint's purpose and requirements.
 // Pass nil for headers or params if not needed.
-func (ns *NatService) AddEndpointWithDoc(path string, description string, headers []HeaderDoc, params []ParameterDoc, endPoint NatsEndpointFunc) error {
+func (ns *NatService) AddEndpointWithDoc(path string, description string, headers []HeaderDoc, params []ParameterDoc, response *ResponseDoc, endPoint NatsEndpointFunc) error {
 	err := ns.AddEndpoint(path, endPoint)
 	if err != nil {
 		return err
@@ -204,6 +205,7 @@ func (ns *NatService) AddEndpointWithDoc(path string, description string, header
 	lastEp.description = description
 	lastEp.headers = headers
 	lastEp.parameters = params
+	lastEp.response = response
 	return nil
 }
 
@@ -213,6 +215,7 @@ type EndpointRegistration struct {
 	Description string
 	Headers     []HeaderDoc
 	Parameters  []ParameterDoc
+	Response    *ResponseDoc
 	Handler     NatsEndpointFunc
 }
 
@@ -230,6 +233,7 @@ func (ns *NatService) AddEndpointWithDocs(endpoints []EndpointRegistration) erro
 		lastEp.description = ep.Description
 		lastEp.headers = ep.Headers
 		lastEp.parameters = ep.Parameters
+		lastEp.response = ep.Response
 	}
 	return nil
 }


### PR DESCRIPTION
- Add ResponseDoc struct with Description, ContentType, and Example fields
- Add Response field to EndpointDoc, NatsEndpoint, and EndpointRegistration
- Update AddEndpointWithDoc() signature to include response parameter
- Update nats-discover CLI to display response info in table and YAML output
- Update all documentation with response examples