### PR TITLE
Refactor _api_docs to use internal endpoint routing

### DIFF
--- a/cmd/nats-discover/main.go
+++ b/cmd/nats-discover/main.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	defaultTimeout = 2 * time.Second
-	version        = "1.0.0"
+	defaultDiscoveryTimeout = 3 * time.Second  // For listing services (broadcast, wait for multiple responses)
+	defaultRequestTimeout   = 10 * time.Second // For API docs request (single response)
+	version                 = "1.0.0"
 )
 
 type config struct {
@@ -58,8 +59,8 @@ func main() {
 	defer nc.Close()
 
 	if cfg.service != "" {
-		// Get API docs for a specific service
-		apiDocs, err := getServiceApiDocs(nc, cfg.service, cfg.timeout)
+		// Get API docs for a specific service (uses defaultRequestTimeout)
+		apiDocs, err := getServiceApiDocs(nc, cfg.service)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting API docs for service '%s': %v\n", cfg.service, err)
 			os.Exit(1)
@@ -88,7 +89,7 @@ func parseFlags() config {
 	flag.StringVar(&cfg.natsURL, "s", "", "NATS server URL (e.g., nats://localhost:4222)")
 	flag.StringVar(&cfg.natsURL, "server", "", "NATS server URL (e.g., nats://localhost:4222)")
 	flag.StringVar(&cfg.contextName, "context", "", "NATS context name (from nats CLI)")
-	flag.DurationVar(&cfg.timeout, "timeout", defaultTimeout, "Timeout for discovery requests")
+	flag.DurationVar(&cfg.timeout, "timeout", defaultDiscoveryTimeout, "Timeout for discovery broadcast (waiting for multiple services to respond)")
 	flag.StringVar(&cfg.format, "format", "table", "Output format: table, json, yaml")
 	flag.BoolVar(&cfg.showVersion, "version", false, "Show version")
 	flag.StringVar(&cfg.service, "service", "", "Service name to get API docs for")
@@ -336,90 +337,29 @@ func discoverServiceList(nc *nats.Conn, timeout time.Duration) ([]nats_service.S
 	return services, nil
 }
 
-// getServiceApiDocs fetches API documentation for a specific service
-func getServiceApiDocs(nc *nats.Conn, serviceName string, timeout time.Duration) (*nats_service.ApiDocsResponse, error) {
-	// First, discover the service to get its API docs subject
-	services, err := discoverServiceList(nc, timeout)
+// getServiceApiDocs fetches API documentation for a specific service.
+// Uses a direct request-response pattern with defaultRequestTimeout.
+// The serviceName is the base path of the service (e.g., "orders.api").
+func getServiceApiDocs(nc *nats.Conn, serviceName string) (*nats_service.ApiDocsResponse, error) {
+	// Construct the API docs subject directly: {serviceName}._api_docs
+	apiDocsSubject := serviceName + "." + nats_service.ApiDocsSubjectSuffix
+
+	// Send a direct request - returns immediately on first response
+	msg, err := nc.Request(apiDocsSubject, nil, defaultRequestTimeout)
 	if err != nil {
-		return nil, err
-	}
-
-	// Find the service
-	var targetService *nats_service.ServiceInfo
-	for i := range services {
-		if services[i].ServiceName == serviceName {
-			targetService = &services[i]
-			break
+		if err == nats.ErrTimeout {
+			return nil, fmt.Errorf("service '%s' not found or not responding (timeout after %v)", serviceName, defaultRequestTimeout)
 		}
+		return nil, fmt.Errorf("failed to get API docs: %w", err)
 	}
 
-	if targetService == nil {
-		return nil, fmt.Errorf("service '%s' not found", serviceName)
+	var apiDocs nats_service.ApiDocsResponse
+	if err := json.Unmarshal(msg.Data, &apiDocs); err != nil {
+		return nil, fmt.Errorf("failed to parse API docs response: %w", err)
 	}
-
-	// If service has an API docs subject, fetch from there
-	if targetService.ApiDocsSubject != "" {
-		msg, err := nc.Request(targetService.ApiDocsSubject, nil, timeout)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get API docs: %w", err)
-		}
-
-		var apiDocs nats_service.ApiDocsResponse
-		if err := json.Unmarshal(msg.Data, &apiDocs); err != nil {
-			return nil, fmt.Errorf("failed to parse API docs response: %w", err)
-		}
-		return &apiDocs, nil
-	}
-
-	// Fallback: try legacy discovery to get endpoints
-	// This handles old services that return full DiscoveryResponse
-	return fetchLegacyApiDocs(nc, serviceName, timeout)
+	return &apiDocs, nil
 }
 
-// fetchLegacyApiDocs fetches endpoints from legacy services that include them in discovery
-func fetchLegacyApiDocs(nc *nats.Conn, serviceName string, timeout time.Duration) (*nats_service.ApiDocsResponse, error) {
-	var result *nats_service.ApiDocsResponse
-	var mu sync.Mutex
-
-	inbox := nc.NewInbox()
-
-	sub, err := nc.Subscribe(inbox, func(msg *nats.Msg) {
-		var legacyResp nats_service.DiscoveryResponse
-		if err := json.Unmarshal(msg.Data, &legacyResp); err != nil {
-			return
-		}
-
-		if legacyResp.ServiceName == serviceName && len(legacyResp.Endpoints) > 0 {
-			mu.Lock()
-			result = &nats_service.ApiDocsResponse{
-				ServiceName:   legacyResp.ServiceName,
-				SubjectPrefix: legacyResp.BasePath,
-				Endpoints:     legacyResp.Endpoints,
-			}
-			mu.Unlock()
-		}
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to subscribe to inbox: %w", err)
-	}
-	defer sub.Unsubscribe()
-
-	if err := nc.PublishRequest(nats_service.DiscoverySubject, inbox, nil); err != nil {
-		return nil, fmt.Errorf("failed to publish discovery request: %w", err)
-	}
-
-	if err := nc.Flush(); err != nil {
-		return nil, fmt.Errorf("failed to flush: %w", err)
-	}
-
-	time.Sleep(timeout)
-
-	if result == nil {
-		return nil, fmt.Errorf("no API docs available for service '%s'", serviceName)
-	}
-
-	return result, nil
-}
 
 // outputServiceList outputs the list of discovered services
 func outputServiceList(services []nats_service.ServiceInfo, format string) error {

--- a/pkg/nats-service/discovery.go
+++ b/pkg/nats-service/discovery.go
@@ -131,28 +131,19 @@ func (ns *NatService) handleDiscoveryRequest(msg *nats.Msg) {
 	}
 }
 
-// registerApiDocsEndpoint subscribes to the API documentation subject.
-// If subscription fails (e.g., due to permissions), the service continues
-// to operate normally with a warning logged.
+// registerApiDocsEndpoint registers the API documentation endpoint as an internal endpoint.
+// This uses the same routing mechanism as user-defined endpoints.
 func (ns *NatService) registerApiDocsEndpoint() {
-	subject := ns.basePath + "." + ApiDocsSubjectSuffix
-	sub, err := ns.nc.Subscribe(subject, ns.handleApiDocsRequest)
+	err := ns.addEndpointInternal(ApiDocsSubjectSuffix, ns.handleApiDocsRequest, true)
 	if err != nil {
-		log.Printf("WARNING: Unable to subscribe to API docs subject '%s': %v. Service will operate normally.", subject, err)
+		log.Printf("WARNING: Unable to register API docs endpoint: %v. Service will operate normally.", err)
 		return
 	}
-
-	if !sub.IsValid() {
-		log.Printf("WARNING: API docs subscription to '%s' is invalid. Service will operate normally.", subject)
-		return
-	}
-
-	log.Printf("Registered API docs endpoint on subject: %s", subject)
-	ns.apiDocsSubscription = sub
+	log.Printf("Registered API docs endpoint on subject: %s.%s", ns.basePath, ApiDocsSubjectSuffix)
 }
 
 // handleApiDocsRequest responds to API documentation requests with full endpoint documentation
-func (ns *NatService) handleApiDocsRequest(msg *nats.Msg) {
+func (ns *NatService) handleApiDocsRequest(msg *NatsMessage) *NatsServiceError {
 	response := ApiDocsResponse{
 		ServiceName:   ns.basePath,
 		SubjectPrefix: ns.basePath,
@@ -163,31 +154,26 @@ func (ns *NatService) handleApiDocsRequest(msg *nats.Msg) {
 
 	jsonData, err := json.Marshal(response)
 	if err != nil {
-		log.Printf("Error marshaling API docs response: %v", err)
-		return
+		msg.Logger.Printf("Error marshaling API docs response: %v", err)
+		svcErr := NewServerError("failed to generate API documentation", 5001, err)
+		return &svcErr
 	}
 
-	if err := msg.Respond(jsonData); err != nil {
-		log.Printf("Error responding to API docs request: %v", err)
-	}
-}
-
-// drainApiDocsSubscription drains the API docs subscription if it exists
-func (ns *NatService) drainApiDocsSubscription() error {
-	if ns.apiDocsSubscription != nil {
-		if err := ns.apiDocsSubscription.Drain(); err != nil {
-			log.Printf("Error draining API docs subscription: %v", err)
-			return err
-		}
-	}
+	msg.ResponseBody = jsonData
 	return nil
 }
+
 
 // buildEndpointDocs creates documentation for all registered endpoints
 func (ns *NatService) buildEndpointDocs() []EndpointDoc {
 	docs := make([]EndpointDoc, 0, len(ns.endPoints))
 
 	for _, ep := range ns.endPoints {
+		// Skip internal endpoints (e.g., _api_docs) - they are not part of the public API
+		if ep.internal {
+			continue
+		}
+
 		doc := EndpointDoc{
 			Path:        ep.path,
 			FullSubject: ns.basePath + "." + ep.path,

--- a/pkg/nats-service/integration_test.go
+++ b/pkg/nats-service/integration_test.go
@@ -1,12 +1,15 @@
 package nats_service_test
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nats-io/nats.go"
 	nats_service "github.com/transactrx/nats-service/pkg/nats-service"
 	nats_service_client "github.com/transactrx/nats-service/pkg/nats-service-client"
 )
@@ -385,5 +388,272 @@ func TestAddEndpointWithDocs(t *testing.T) {
 	}
 	if string(response.Data) != string(testData) {
 		t.Errorf("Echo: expected '%s', got '%s'", string(testData), string(response.Data))
+	}
+}
+
+// TestDiscoveryIntegration tests the service discovery and API docs functionality
+func TestDiscoveryIntegration(t *testing.T) {
+	natsURL := os.Getenv("NATS_URL")
+	if natsURL == "" {
+		natsURL = "nats://localhost:4222"
+	}
+
+	queueName := os.Getenv("NATS_QUEUE_NAME")
+	if queueName == "" {
+		queueName = "testing-discovery"
+	}
+
+	// Create service with documented endpoints
+	natService, err := nats_service.NewLowLevelDebug("discovery.test.api", queueName, natsURL, "", "", 1024*2, 1024*300, false)
+	if err != nil {
+		t.Skipf("Skipping test as NATS is not available: %v", err)
+		return
+	}
+
+	// Set service description
+	natService.SetDescription("Test service for discovery integration tests")
+
+	// Define handlers
+	healthHandler := func(msg *nats_service.NatsMessage) *nats_service.NatsServiceError {
+		msg.ResponseBody = []byte(`{"status":"healthy"}`)
+		return nil
+	}
+	getUserHandler := func(msg *nats_service.NatsMessage) *nats_service.NatsServiceError {
+		userID := msg.Parameters["userId"]
+		msg.ResponseBody = []byte(`{"id":"` + userID + `","name":"Test User"}`)
+		return nil
+	}
+
+	// Register endpoints with documentation
+	endpoints := []nats_service.EndpointRegistration{
+		{
+			Path:        "health",
+			Description: "Health check endpoint",
+			Response:    &nats_service.ResponseDoc{Description: "Health status", ContentType: "application/json"},
+			Handler:     healthHandler,
+		},
+		{
+			Path:        "users.:userId",
+			Description: "Get user by ID",
+			Parameters: []nats_service.ParameterDoc{
+				{Name: "userId", Description: "User identifier", Required: true, Example: "user-123"},
+			},
+			Headers: []nats_service.HeaderDoc{
+				{Name: "Authorization", Description: "Bearer token", Required: true},
+			},
+			Response: &nats_service.ResponseDoc{Description: "User object", ContentType: "application/json"},
+			Handler:  getUserHandler,
+		},
+	}
+
+	err = natService.AddEndpointWithDocs(endpoints)
+	if err != nil {
+		t.Fatalf("Failed to add endpoints: %v", err)
+	}
+
+	err = natService.Start()
+	if err != nil {
+		t.Fatalf("Failed to start service: %v", err)
+	}
+	defer natService.Shutdown()
+
+	// Connect directly to NATS for discovery tests
+	nc, err := nats.Connect(natsURL)
+	if err != nil {
+		t.Fatalf("Failed to connect to NATS: %v", err)
+	}
+	defer nc.Close()
+
+	// Run discovery tests
+	t.Run("TestServiceDiscovery", func(t *testing.T) {
+		testServiceDiscovery(t, nc)
+	})
+
+	t.Run("TestApiDocsEndpoint", func(t *testing.T) {
+		testApiDocsEndpoint(t, nc)
+	})
+
+	t.Run("TestReservedEndpointRejection", func(t *testing.T) {
+		testReservedEndpointRejection(t, natsURL, queueName)
+	})
+}
+
+// testServiceDiscovery tests the _discovery.all broadcast
+func testServiceDiscovery(t *testing.T, nc *nats.Conn) {
+	var results []nats_service.ServiceInfo
+	var mu sync.Mutex
+
+	// Subscribe to collect responses
+	inbox := nc.NewInbox()
+	sub, err := nc.Subscribe(inbox, func(msg *nats.Msg) {
+		var info nats_service.ServiceInfo
+		if err := json.Unmarshal(msg.Data, &info); err != nil {
+			return
+		}
+		mu.Lock()
+		results = append(results, info)
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatalf("Failed to subscribe: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	// Send discovery broadcast
+	err = nc.PublishRequest(nats_service.DiscoverySubject, inbox, nil)
+	if err != nil {
+		t.Fatalf("Failed to publish discovery request: %v", err)
+	}
+	nc.Flush()
+
+	// Wait for responses
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify we got at least one service
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(results) == 0 {
+		t.Fatalf("No services discovered")
+	}
+
+	// Find our test service
+	var found *nats_service.ServiceInfo
+	for i := range results {
+		if results[i].ServiceName == "discovery.test.api" {
+			found = &results[i]
+			break
+		}
+	}
+
+	if found == nil {
+		t.Fatalf("Test service 'discovery.test.api' not found in discovery results")
+	}
+
+	// Verify service info
+	if found.SubjectPrefix != "discovery.test.api" {
+		t.Errorf("Expected SubjectPrefix 'discovery.test.api', got '%s'", found.SubjectPrefix)
+	}
+
+	if found.Description != "Test service for discovery integration tests" {
+		t.Errorf("Expected description 'Test service for discovery integration tests', got '%s'", found.Description)
+	}
+
+	expectedApiDocsSubject := "discovery.test.api._api_docs"
+	if found.ApiDocsSubject != expectedApiDocsSubject {
+		t.Errorf("Expected ApiDocsSubject '%s', got '%s'", expectedApiDocsSubject, found.ApiDocsSubject)
+	}
+}
+
+// testApiDocsEndpoint tests the _api_docs request-response endpoint
+func testApiDocsEndpoint(t *testing.T, nc *nats.Conn) {
+	// Send direct request to API docs endpoint
+	apiDocsSubject := "discovery.test.api._api_docs"
+	msg, err := nc.Request(apiDocsSubject, nil, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Failed to get API docs: %v", err)
+	}
+
+	// Parse response
+	var apiDocs nats_service.ApiDocsResponse
+	if err := json.Unmarshal(msg.Data, &apiDocs); err != nil {
+		t.Fatalf("Failed to parse API docs response: %v", err)
+	}
+
+	// Verify service info
+	if apiDocs.ServiceName != "discovery.test.api" {
+		t.Errorf("Expected ServiceName 'discovery.test.api', got '%s'", apiDocs.ServiceName)
+	}
+
+	if apiDocs.Description != "Test service for discovery integration tests" {
+		t.Errorf("Expected description, got '%s'", apiDocs.Description)
+	}
+
+	// Verify we have status codes
+	if len(apiDocs.StatusCodes) == 0 {
+		t.Error("Expected status codes in response")
+	}
+
+	// Verify endpoints
+	if len(apiDocs.Endpoints) != 2 {
+		t.Fatalf("Expected 2 endpoints, got %d", len(apiDocs.Endpoints))
+	}
+
+	// Find and verify the health endpoint
+	var healthEndpoint, userEndpoint *nats_service.EndpointDoc
+	for i := range apiDocs.Endpoints {
+		if apiDocs.Endpoints[i].Path == "health" {
+			healthEndpoint = &apiDocs.Endpoints[i]
+		}
+		if apiDocs.Endpoints[i].Path == "users.:userId" {
+			userEndpoint = &apiDocs.Endpoints[i]
+		}
+	}
+
+	if healthEndpoint == nil {
+		t.Fatal("Health endpoint not found in API docs")
+	}
+	if healthEndpoint.Description != "Health check endpoint" {
+		t.Errorf("Health endpoint description mismatch: %s", healthEndpoint.Description)
+	}
+	if healthEndpoint.FullSubject != "discovery.test.api.health" {
+		t.Errorf("Health endpoint FullSubject mismatch: %s", healthEndpoint.FullSubject)
+	}
+
+	if userEndpoint == nil {
+		t.Fatal("User endpoint not found in API docs")
+	}
+	if userEndpoint.Description != "Get user by ID" {
+		t.Errorf("User endpoint description mismatch: %s", userEndpoint.Description)
+	}
+
+	// Verify user endpoint has parameters
+	if len(userEndpoint.Parameters) != 1 {
+		t.Fatalf("Expected 1 parameter for user endpoint, got %d", len(userEndpoint.Parameters))
+	}
+	if userEndpoint.Parameters[0].Name != "userId" {
+		t.Errorf("Expected parameter name 'userId', got '%s'", userEndpoint.Parameters[0].Name)
+	}
+	if userEndpoint.Parameters[0].Description != "User identifier" {
+		t.Errorf("Expected parameter description 'User identifier', got '%s'", userEndpoint.Parameters[0].Description)
+	}
+
+	// Verify user endpoint has headers
+	if len(userEndpoint.Headers) != 1 {
+		t.Fatalf("Expected 1 header for user endpoint, got %d", len(userEndpoint.Headers))
+	}
+	if userEndpoint.Headers[0].Name != "Authorization" {
+		t.Errorf("Expected header name 'Authorization', got '%s'", userEndpoint.Headers[0].Name)
+	}
+
+	// Verify example subject is generated
+	if userEndpoint.ExampleSubject == "" {
+		t.Error("Expected ExampleSubject to be generated for parameterized endpoint")
+	}
+	if !strings.Contains(userEndpoint.ExampleSubject, "user-123") {
+		t.Errorf("ExampleSubject should contain example value 'user-123', got '%s'", userEndpoint.ExampleSubject)
+	}
+}
+
+// testReservedEndpointRejection verifies that users cannot register endpoints with reserved suffixes
+func testReservedEndpointRejection(t *testing.T, natsURL, queueName string) {
+	natService, err := nats_service.NewLowLevelDebug("reserved.test.api", queueName+"-reserved", natsURL, "", "", 1024*2, 1024*300, false)
+	if err != nil {
+		t.Skipf("Skipping test as NATS is not available: %v", err)
+		return
+	}
+
+	// Try to register an endpoint with reserved suffix
+	handler := func(msg *nats_service.NatsMessage) *nats_service.NatsServiceError {
+		return nil
+	}
+
+	err = natService.AddEndpoint("my_api_docs", handler)
+	if err == nil {
+		t.Error("Expected error when registering endpoint with reserved suffix '_api_docs'")
+	}
+
+	if !strings.Contains(err.Error(), "reserved suffix") {
+		t.Errorf("Error should mention 'reserved suffix', got: %v", err)
 	}
 }

--- a/pkg/nats-service/nats-service.go
+++ b/pkg/nats-service/nats-service.go
@@ -25,7 +25,6 @@ type NatService struct {
 	chunkedSubscription         *nats.Subscription
 	chunkedReceiverSubscription *nats.Subscription
 	discoverySubscription       *nats.Subscription
-	apiDocsSubscription         *nats.Subscription
 	chunkCache                  *ttlcache.Cache[string, [][]byte]
 	endPoints                   []*NatsEndpoint
 	basePath                    string
@@ -60,6 +59,7 @@ type NatsEndpoint struct {
 	headers          []HeaderDoc
 	parameters       []ParameterDoc
 	response         *ResponseDoc
+	internal         bool // true for library-reserved endpoints (e.g., _api_docs)
 }
 
 type NatsEndpointFunc func(msg *NatsMessage) *NatsServiceError
@@ -125,7 +125,12 @@ func NewLowLevelDebug(basePath, natsQueueName, natsUrl, natsToken, natsKey strin
 }
 
 func (ns *NatService) AddEndpoint(path string, endPoint NatsEndpointFunc) error {
+	return ns.addEndpointInternal(path, endPoint, false)
+}
 
+// addEndpointInternal is the internal implementation for adding endpoints.
+// The internal flag allows the library to register reserved endpoints.
+func (ns *NatService) addEndpointInternal(path string, endPoint NatsEndpointFunc, internal bool) error {
 	path = strings.TrimSpace(path)
 	if path == "" {
 		return fmt.Errorf("endpoint path cannot be empty")
@@ -133,6 +138,11 @@ func (ns *NatService) AddEndpoint(path string, endPoint NatsEndpointFunc) error 
 
 	if endPoint == nil {
 		return fmt.Errorf("endpoint cannot be nil: %w", ConfigError)
+	}
+
+	// Check for reserved suffixes (only for external registrations)
+	if !internal && strings.HasSuffix(path, ApiDocsSubjectSuffix) {
+		return fmt.Errorf("endpoint path '%s' uses reserved suffix '%s': %w", path, ApiDocsSubjectSuffix, ConfigError)
 	}
 
 	pathSeparator := "."
@@ -150,6 +160,7 @@ func (ns *NatService) AddEndpoint(path string, endPoint NatsEndpointFunc) error 
 		path:          path,
 		endPointFunc:  endPoint,
 		pathSeparator: pathSeparator,
+		internal:      internal,
 	}
 
 	hasWildcardSuffix := strings.HasSuffix(path, ">")
@@ -252,6 +263,9 @@ func (ns *NatService) Start() error {
 		return fmt.Errorf("no endpoints configured")
 	}
 
+	// Register internal API docs endpoint before starting the main subscription
+	ns.registerApiDocsEndpoint()
+
 	subscribe, err := ns.nc.QueueSubscribe(ns.basePath+".>", ns.queueName, func(msg *nats.Msg) {
 		for _, endPoint := range ns.endPoints {
 			if msg.Subject == ns.basePath {
@@ -297,9 +311,6 @@ func (ns *NatService) Start() error {
 
 	// Register discovery endpoint (non-blocking, graceful degradation on failure)
 	ns.registerDiscoveryEndpoint()
-
-	// Register API docs endpoint (non-blocking, graceful degradation on failure)
-	ns.registerApiDocsEndpoint()
 
 	return nil
 }
@@ -501,9 +512,7 @@ func (ns *NatService) Shutdown() error {
 	// Drain discovery subscription first (non-blocking if not registered)
 	ns.drainDiscoverySubscription()
 
-	// Drain API docs subscription (non-blocking if not registered)
-	ns.drainApiDocsSubscription()
-
+	// API docs endpoint is handled by the main subscription, no separate drain needed
 	return ns.subscription.Drain()
 }
 


### PR DESCRIPTION
- Register _api_docs as an internal endpoint through existing routing mechanism instead of separate NATS subscription
- Add reserved suffix validation to prevent users from registering endpoints ending with _api_docs
- Add internal flag to NatsEndpoint to mark library-reserved endpoints
- Filter internal endpoints from API docs response
- Update CLI timeouts: 3s for discovery broadcast, 10s for API docs request
- Simplify CLI getServiceApiDocs to use direct request without discovery
- Add comprehensive discovery integration tests