### PR TITLE
Add repository URL to service discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,10 +88,11 @@ cd cmd/requester-example && NATS_URL=nats://localhost:4222 go run main.go
 - Automatic decompression by recipient
 
 **Endpoint Discovery**: Services automatically register for discovery
-- Discovery subject: `_discovery.all` returns basic service info (name, prefix, description)
+- Discovery subject: `_discovery.all` returns basic service info (name, prefix, description, repository URL)
 - API docs subject: `{basePath}._api_docs` returns full endpoint documentation
 - Two-phase discovery: list services first, then fetch details for specific service
 - Use `SetDescription()` to add a service description for discovery
+- Use `SetRepositoryURL()` to add a git repository URL for source code access
 - Graceful degradation if subscription fails (service continues normally)
 
 ### Important Implementation Details
@@ -223,8 +224,9 @@ nats-discover -s nats://localhost:4222 --timeout 5s
 
 ### Registering Endpoints with Documentation
 ```go
-// Set service description (shown in discovery responses)
+// Set service metadata (shown in discovery responses)
 service.SetDescription("Order management API - handles order CRUD operations")
+service.SetRepositoryURL("https://github.com/transactrx/order-service")
 
 // Single endpoint with description (pass nil for headers/params/response if not needed)
 err := service.AddEndpointWithDoc("users.:userId", "Get user by ID", nil, nil, nil, userHandler)

--- a/cmd/nats-discover/main.go
+++ b/cmd/nats-discover/main.go
@@ -392,22 +392,41 @@ func outputServiceList(services []nats_service.ServiceInfo, format string) error
 			if svc.Description != "" {
 				fmt.Printf("description: %s\n", svc.Description)
 			}
+			if svc.RepositoryURL != "" {
+				fmt.Printf("repositoryUrl: %s\n", svc.RepositoryURL)
+			}
 			if svc.ApiDocsSubject != "" {
 				fmt.Printf("apiDocsSubject: %s\n", svc.ApiDocsSubject)
 			}
 		}
 	case "table":
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintf(w, "SERVICE\tSUBJECT PREFIX\tDESCRIPTION\n")
-		fmt.Fprintf(w, "-------\t--------------\t-----------\n")
-		for _, svc := range services {
-			desc := svc.Description
-			if len(desc) > 50 {
-				desc = desc[:47] + "..."
+		// Header
+		fmt.Printf("%-50s %-50s %s\n", "SERVICE", "SUBJECT PREFIX", "REPOSITORY")
+		fmt.Printf("%-50s %-50s %s\n", strings.Repeat("-", 50), strings.Repeat("-", 50), strings.Repeat("-", 100))
+
+		for i, svc := range services {
+			// Line 1: service, prefix, repo URL
+			serviceName := truncateString(svc.ServiceName, 50)
+			subjectPrefix := truncateString(svc.SubjectPrefix, 50)
+			repoURL := truncateString(svc.RepositoryURL, 100)
+			if repoURL == "" {
+				repoURL = "-"
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\n", svc.ServiceName, svc.SubjectPrefix, desc)
+			fmt.Printf("%-50s %-50s %s\n", serviceName, subjectPrefix, repoURL)
+
+			// Line 2: description (wrapped)
+			if svc.Description != "" {
+				wrappedDesc := wrapText(svc.Description, 150)
+				for _, line := range wrappedDesc {
+					fmt.Printf("  %s\n", line)
+				}
+			}
+
+			// Empty line between services (but not after the last one)
+			if i < len(services)-1 {
+				fmt.Println()
+			}
 		}
-		w.Flush()
 	default:
 		return fmt.Errorf("unknown format: %s (supported: table, json, yaml)", format)
 	}
@@ -433,6 +452,9 @@ func outputApiDocs(apiDocs *nats_service.ApiDocsResponse, format string) error {
 		fmt.Printf("subjectPrefix: %s\n", apiDocs.SubjectPrefix)
 		if apiDocs.Description != "" {
 			fmt.Printf("description: %s\n", apiDocs.Description)
+		}
+		if apiDocs.RepositoryURL != "" {
+			fmt.Printf("repositoryUrl: %s\n", apiDocs.RepositoryURL)
 		}
 		if len(apiDocs.StatusCodes) > 0 {
 			fmt.Println("statusCodes:")
@@ -517,6 +539,9 @@ func outputApiDocs(apiDocs *nats_service.ApiDocsResponse, format string) error {
 		if apiDocs.Description != "" {
 			fmt.Printf("Description: %s\n", apiDocs.Description)
 		}
+		if apiDocs.RepositoryURL != "" {
+			fmt.Printf("Repository: %s\n", apiDocs.RepositoryURL)
+		}
 		fmt.Println()
 		fmt.Fprintf(w, "SUBJECT PATTERN\tEXAMPLE\tDESCRIPTION\n")
 		fmt.Fprintf(w, "---------------\t-------\t-----------\n")
@@ -564,4 +589,43 @@ func outputApiDocs(apiDocs *nats_service.ApiDocsResponse, format string) error {
 		return fmt.Errorf("unknown format: %s (supported: table, json, yaml)", format)
 	}
 	return nil
+}
+
+// truncateString truncates a string to maxLen characters, adding "..." if truncated
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// wrapText wraps text to the specified width, breaking on word boundaries
+func wrapText(text string, width int) []string {
+	if len(text) <= width {
+		return []string{text}
+	}
+
+	var lines []string
+	words := strings.Fields(text)
+	var currentLine string
+
+	for _, word := range words {
+		if currentLine == "" {
+			currentLine = word
+		} else if len(currentLine)+1+len(word) <= width {
+			currentLine += " " + word
+		} else {
+			lines = append(lines, currentLine)
+			currentLine = word
+		}
+	}
+
+	if currentLine != "" {
+		lines = append(lines, currentLine)
+	}
+
+	return lines
 }

--- a/pkg/nats-service/discovery.go
+++ b/pkg/nats-service/discovery.go
@@ -19,6 +19,7 @@ type ServiceInfo struct {
 	ServiceName    string `json:"serviceName"`
 	SubjectPrefix  string `json:"subjectPrefix"`
 	Description    string `json:"description,omitempty"`
+	RepositoryURL  string `json:"repositoryUrl,omitempty"`
 	ApiDocsSubject string `json:"apiDocsSubject,omitempty"`
 }
 
@@ -27,6 +28,7 @@ type ApiDocsResponse struct {
 	ServiceName   string          `json:"serviceName"`
 	SubjectPrefix string          `json:"subjectPrefix"`
 	Description   string          `json:"description,omitempty"`
+	RepositoryURL string          `json:"repositoryUrl,omitempty"`
 	StatusCodes   []StatusCodeDoc `json:"statusCodes,omitempty"` // Standard status codes for all endpoints
 	Endpoints     []EndpointDoc   `json:"endpoints"`
 }
@@ -117,6 +119,7 @@ func (ns *NatService) handleDiscoveryRequest(msg *nats.Msg) {
 		ServiceName:    ns.basePath,
 		SubjectPrefix:  ns.basePath,
 		Description:    ns.description,
+		RepositoryURL:  ns.repositoryURL,
 		ApiDocsSubject: ns.basePath + "." + ApiDocsSubjectSuffix,
 	}
 
@@ -148,6 +151,7 @@ func (ns *NatService) handleApiDocsRequest(msg *NatsMessage) *NatsServiceError {
 		ServiceName:   ns.basePath,
 		SubjectPrefix: ns.basePath,
 		Description:   ns.description,
+		RepositoryURL: ns.repositoryURL,
 		StatusCodes:   standardStatusCodes(),
 		Endpoints:     ns.buildEndpointDocs(),
 	}

--- a/pkg/nats-service/nats-service.go
+++ b/pkg/nats-service/nats-service.go
@@ -30,6 +30,7 @@ type NatService struct {
 	basePath                    string
 	queueName                   string
 	description                 string
+	repositoryURL               string
 	maxRespSizeToCompress       int
 	maxRespSizeToChunk          int
 	debug                       bool
@@ -86,6 +87,13 @@ func (ns *NatService) GetNatsService() *nats.Conn {
 // This should be called before Start() to ensure the description is available during discovery.
 func (ns *NatService) SetDescription(description string) {
 	ns.description = description
+}
+
+// SetRepositoryURL sets the git repository URL for the service source code.
+// This helps users and coding agents find the source to better understand the microservice.
+// This should be called before Start() to ensure the URL is available during discovery.
+func (ns *NatService) SetRepositoryURL(url string) {
+	ns.repositoryURL = url
 }
 
 func NewLowLevel(basePath, natsQueueName, natsUrl, natsToken, natsKey string, maxRespSizeToCompress, maxRespSizeToChunk int) (*NatService, error) {


### PR DESCRIPTION
## Summary
- Add `SetRepositoryURL()` method to configure git repo URL for services
- Include `repositoryUrl` in `ServiceInfo` and `ApiDocsResponse` structs
- Update nats-discover CLI table output with improved formatting
- Update CLAUDE.md documentation

## Test plan
- [x] GitHub Actions tests passed on Development branch

🤖 Generated with [Claude Code](https://claude.ai/code)