### PR TITLE
Add endpoint stats tracking and broadcast stats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,159 @@ go run ./cmd/nats-discover -s nats://localhost:4222
 5. **Add Health Checks**: Include a health endpoint for monitoring
 6. **Use Correlation IDs**: Pass correlation IDs through headers for distributed tracing
 
+## Coding Agent Prompt for Full Service Documentation
+
+When using a coding agent (like Claude) to document your nats-service microservice, use the following prompt to ensure complete and thorough documentation of all endpoints and the service itself:
+
+---
+
+**Prompt:**
+
+```
+Analyze this nats-service microservice and add complete documentation for endpoint discovery. Follow these steps:
+
+## Step 1: Understand the Service
+- Read the main.go and all handler files to understand what this service does
+- Identify the service's purpose, domain, and responsibilities
+- Find the git repository URL for this project
+
+## Step 2: Configure Service Metadata
+Add these calls before service.Start():
+- SetDescription(): Write a clear 1-2 sentence description of what this service does
+- SetRepositoryURL(): Set the git origin URL so users can find the source code
+
+## Step 3: Document Each Endpoint
+For EVERY endpoint, ensure AddEndpointWithDoc() or AddEndpointWithDocs() includes:
+
+### Path & Description
+- path: The NATS subject pattern (e.g., "orders.:orderId")
+- description: Clear explanation of what this endpoint does (1-2 sentences)
+
+### Parameters ([]ParameterDoc)
+For each path parameter (e.g., :userId, :orderId):
+- Name: Parameter name (must match the :param in path)
+- Description: What this parameter represents
+- Required: true for path parameters
+- Example: A realistic example value (e.g., "USR-123", "ORD-456")
+
+### Headers ([]HeaderDoc)
+For each expected request header:
+- Name: Header name (e.g., "Authorization", "X-Tenant-ID")
+- Description: What this header is for
+- Required: true/false
+- Example: Example value (e.g., "Bearer eyJ...")
+
+### Response (*ResponseDoc)
+- Description: What the response contains
+- ContentType: MIME type (e.g., "application/json")
+- Example: A realistic JSON example of the response
+- Headers: Any custom response headers returned
+
+## Step 4: Verify Completeness
+Ensure every endpoint has:
+- [ ] Meaningful description (not just the path repeated)
+- [ ] All path parameters documented with examples
+- [ ] All expected headers documented
+- [ ] Response documentation with content type
+- [ ] Realistic examples that help users understand the data format
+
+## Output Format
+Provide the complete code changes needed to fully document this service.
+```
+
+---
+
+### Example of Complete Documentation
+
+```go
+func main() {
+    service, _ := nats_service.New("orders.api")
+
+    // Service metadata
+    service.SetDescription("Order management service - handles order creation, retrieval, updates, and fulfillment workflows")
+    service.SetRepositoryURL("https://github.com/mycompany/order-service")
+
+    // Fully documented endpoints
+    endpoints := []nats_service.EndpointRegistration{
+        {
+            Path:        "health",
+            Description: "Health check endpoint for monitoring and load balancer probes",
+            Response: &nats_service.ResponseDoc{
+                Description: "Service health status",
+                ContentType: "application/json",
+                Example:     `{"status": "healthy", "timestamp": "2024-01-15T10:30:00Z"}`,
+            },
+            Handler: healthHandler,
+        },
+        {
+            Path:        "orders.:orderId",
+            Description: "Retrieve a specific order by its unique identifier",
+            Headers: []nats_service.HeaderDoc{
+                {
+                    Name:        "Authorization",
+                    Description: "Bearer token for authentication",
+                    Required:    true,
+                    Example:     "Bearer eyJhbGciOiJIUzI1NiIs...",
+                },
+                {
+                    Name:        "X-Tenant-ID",
+                    Description: "Tenant identifier for multi-tenant isolation",
+                    Required:    true,
+                    Example:     "tenant-abc-123",
+                },
+            },
+            Parameters: []nats_service.ParameterDoc{
+                {
+                    Name:        "orderId",
+                    Description: "Unique order identifier (UUID format)",
+                    Required:    true,
+                    Example:     "ord-550e8400-e29b-41d4-a716-446655440000",
+                },
+            },
+            Response: &nats_service.ResponseDoc{
+                Description: "Complete order details including line items and status",
+                ContentType: "application/json",
+                Example:     `{"id": "ord-550e8400-e29b-41d4-a716-446655440000", "status": "pending", "total": 99.99, "items": [{"sku": "PROD-001", "qty": 2}]}`,
+            },
+            Handler: getOrderHandler,
+        },
+        {
+            Path:        "orders.customer.:customerId",
+            Description: "List all orders for a specific customer with optional filtering",
+            Headers: []nats_service.HeaderDoc{
+                {Name: "Authorization", Description: "Bearer token", Required: true},
+            },
+            Parameters: []nats_service.ParameterDoc{
+                {
+                    Name:        "customerId",
+                    Description: "Customer's unique identifier",
+                    Required:    true,
+                    Example:     "cust-12345",
+                },
+            },
+            Response: &nats_service.ResponseDoc{
+                Description: "Paginated list of customer orders",
+                ContentType: "application/json",
+                Example:     `{"orders": [...], "total": 42, "page": 1, "pageSize": 20}`,
+            },
+            Handler: getCustomerOrdersHandler,
+        },
+    }
+
+    service.AddEndpointWithDocs(endpoints)
+    service.Start()
+}
+```
+
+### Documentation Quality Checklist
+
+| Field | Bad Example | Good Example |
+|-------|-------------|--------------|
+| Description | "Get order" | "Retrieve a specific order by its unique identifier including line items, shipping info, and payment status" |
+| Parameter Example | "123" | "ord-550e8400-e29b-41d4-a716-446655440000" |
+| Header Example | "token" | "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." |
+| Response Example | `{}` | `{"id": "ord-123", "status": "pending", "items": [...]}` |
+
 ## License
 
 See [LICENSE](LICENSE) file.

--- a/cmd/nats-discover/main.go
+++ b/cmd/nats-discover/main.go
@@ -30,7 +30,8 @@ type config struct {
 	timeout     time.Duration
 	format      string
 	showVersion bool
-	service     string // specific service to get API docs for
+	service     string // specific service to get API docs or stats for
+	stats       bool   // get stats instead of API docs
 	creds       string
 	nkey        string
 	jwt         string
@@ -60,7 +61,22 @@ func main() {
 	}
 	defer nc.Close()
 
-	if cfg.service != "" {
+	if cfg.stats {
+		// Get stats for a service (requires service name)
+		if cfg.service == "" {
+			fmt.Fprintf(os.Stderr, "Error: --stats requires -S/--service to specify the service\n")
+			os.Exit(1)
+		}
+		stats, err := getServiceStats(nc, cfg.service, cfg.timeout)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting stats for service '%s': %v\n", cfg.service, err)
+			os.Exit(1)
+		}
+		if err := outputStats(stats, cfg.format); err != nil {
+			fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+			os.Exit(1)
+		}
+	} else if cfg.service != "" {
 		// Get API docs for a specific service (uses defaultRequestTimeout)
 		apiDocs, err := getServiceApiDocs(nc, cfg.service)
 		if err != nil {
@@ -94,8 +110,9 @@ func parseFlags() config {
 	flag.DurationVar(&cfg.timeout, "timeout", defaultDiscoveryTimeout, "Timeout for discovery broadcast (waiting for multiple services to respond)")
 	flag.StringVar(&cfg.format, "format", "table", "Output format: table, json, yaml")
 	flag.BoolVar(&cfg.showVersion, "version", false, "Show version")
-	flag.StringVar(&cfg.service, "service", "", "Service name to get API docs for")
-	flag.StringVar(&cfg.service, "S", "", "Service name to get API docs for (shorthand)")
+	flag.StringVar(&cfg.service, "service", "", "Service name to get API docs or stats for")
+	flag.StringVar(&cfg.service, "S", "", "Service name to get API docs or stats for (shorthand)")
+	flag.BoolVar(&cfg.stats, "stats", false, "Get stats for a service (requires -S/--service)")
 	flag.StringVar(&cfg.creds, "creds", "", "Path to credentials file")
 	flag.StringVar(&cfg.nkey, "nkey", "", "Path to NKey file")
 	flag.StringVar(&cfg.jwt, "jwt", "", "JWT token for authentication")
@@ -107,8 +124,9 @@ func parseFlags() config {
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
-		fmt.Fprintf(os.Stderr, "  nats-discover -s nats://localhost:4222                    # List all services\n")
-		fmt.Fprintf(os.Stderr, "  nats-discover -s nats://localhost:4222 -S orders.api      # Show endpoints for orders.api\n")
+		fmt.Fprintf(os.Stderr, "  nats-discover -s nats://localhost:4222                         # List all services\n")
+		fmt.Fprintf(os.Stderr, "  nats-discover -s nats://localhost:4222 -S orders.api           # Show endpoints for orders.api\n")
+		fmt.Fprintf(os.Stderr, "  nats-discover -s nats://localhost:4222 -S orders.api --stats   # Show stats for all instances\n")
 		fmt.Fprintf(os.Stderr, "  nats-discover -s nats://localhost:4222 --service orders.api --format json\n")
 	}
 
@@ -366,6 +384,214 @@ func getServiceApiDocs(nc *nats.Conn, serviceName string) (*nats_service.ApiDocs
 		return nil, fmt.Errorf("failed to parse API docs response: %w", err)
 	}
 	return &apiDocs, nil
+}
+
+// AggregatedStats contains combined stats from all instances of a service
+type AggregatedStats struct {
+	ServiceName    string                              `json:"serviceName"`
+	InstanceCount  int                                 `json:"instanceCount"`
+	Instances      []nats_service.InstanceStatsResponse `json:"instances"`
+	AggregatedEndpoints []AggregatedEndpointStats      `json:"aggregatedEndpoints"`
+}
+
+// AggregatedEndpointStats contains combined stats for a single endpoint across all instances
+type AggregatedEndpointStats struct {
+	Subject       string  `json:"subject"`
+	TotalSuccess  int64   `json:"totalSuccess"`
+	TotalFailures int64   `json:"totalFailures"`
+	MinLatencyMs  float64 `json:"minLatencyMs"`
+	MaxLatencyMs  float64 `json:"maxLatencyMs"`
+	AvgLatencyMs  float64 `json:"avgLatencyMs"`
+	// Per-instance percentiles (aggregating percentiles is statistically complex)
+	P50Range string `json:"p50RangeMs"`
+	P95Range string `json:"p95RangeMs"`
+}
+
+// getServiceStats collects stats from all instances of a service
+func getServiceStats(nc *nats.Conn, serviceName string, timeout time.Duration) (*AggregatedStats, error) {
+	results := make([]nats_service.InstanceStatsResponse, 0)
+	var mu sync.Mutex
+
+	// Create an inbox for receiving responses
+	inbox := nc.NewInbox()
+
+	// Subscribe to the inbox
+	sub, err := nc.Subscribe(inbox, func(msg *nats.Msg) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		var instanceStats nats_service.InstanceStatsResponse
+		if err := json.Unmarshal(msg.Data, &instanceStats); err != nil {
+			return // Skip malformed responses
+		}
+		results = append(results, instanceStats)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe to inbox: %w", err)
+	}
+	defer sub.Unsubscribe()
+
+	// Publish stats request (broadcast - all instances respond)
+	statsSubject := serviceName + "." + nats_service.StatsSubjectSuffix
+	if err := nc.PublishRequest(statsSubject, inbox, nil); err != nil {
+		return nil, fmt.Errorf("failed to publish stats request: %w", err)
+	}
+
+	// Flush to ensure the message is sent
+	if err := nc.Flush(); err != nil {
+		return nil, fmt.Errorf("failed to flush: %w", err)
+	}
+
+	// Wait for responses
+	time.Sleep(timeout)
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("no instances responded for service '%s'", serviceName)
+	}
+
+	// Aggregate results
+	aggregated := &AggregatedStats{
+		ServiceName:   serviceName,
+		InstanceCount: len(results),
+		Instances:     results,
+	}
+
+	// Aggregate endpoint stats across instances
+	endpointMap := make(map[string]*AggregatedEndpointStats)
+	endpointP50s := make(map[string][]float64)
+	endpointP95s := make(map[string][]float64)
+	endpointAvgSums := make(map[string]float64)
+	endpointCounts := make(map[string]int64)
+
+	for _, instance := range results {
+		for _, ep := range instance.Endpoints {
+			if _, ok := endpointMap[ep.Subject]; !ok {
+				endpointMap[ep.Subject] = &AggregatedEndpointStats{
+					Subject:      ep.Subject,
+					MinLatencyMs: ep.Latency.Min,
+					MaxLatencyMs: ep.Latency.Max,
+				}
+				endpointP50s[ep.Subject] = make([]float64, 0)
+				endpointP95s[ep.Subject] = make([]float64, 0)
+			}
+
+			agg := endpointMap[ep.Subject]
+			agg.TotalSuccess += ep.Success
+			agg.TotalFailures += ep.Failures
+
+			if ep.Latency.Min < agg.MinLatencyMs || agg.MinLatencyMs == 0 {
+				agg.MinLatencyMs = ep.Latency.Min
+			}
+			if ep.Latency.Max > agg.MaxLatencyMs {
+				agg.MaxLatencyMs = ep.Latency.Max
+			}
+
+			// Track for weighted average
+			endpointAvgSums[ep.Subject] += ep.Latency.Avg * float64(ep.Latency.Count)
+			endpointCounts[ep.Subject] += ep.Latency.Count
+
+			// Track percentiles for range display
+			if ep.Latency.Count > 0 {
+				endpointP50s[ep.Subject] = append(endpointP50s[ep.Subject], ep.Latency.P50)
+				endpointP95s[ep.Subject] = append(endpointP95s[ep.Subject], ep.Latency.P95)
+			}
+		}
+	}
+
+	// Calculate weighted averages and percentile ranges
+	for subject, agg := range endpointMap {
+		if endpointCounts[subject] > 0 {
+			agg.AvgLatencyMs = endpointAvgSums[subject] / float64(endpointCounts[subject])
+		}
+
+		p50s := endpointP50s[subject]
+		p95s := endpointP95s[subject]
+
+		if len(p50s) > 0 {
+			sort.Float64s(p50s)
+			sort.Float64s(p95s)
+			agg.P50Range = fmt.Sprintf("%.2f-%.2f", p50s[0], p50s[len(p50s)-1])
+			agg.P95Range = fmt.Sprintf("%.2f-%.2f", p95s[0], p95s[len(p95s)-1])
+		}
+
+		aggregated.AggregatedEndpoints = append(aggregated.AggregatedEndpoints, *agg)
+	}
+
+	// Sort by subject
+	sort.Slice(aggregated.AggregatedEndpoints, func(i, j int) bool {
+		return aggregated.AggregatedEndpoints[i].Subject < aggregated.AggregatedEndpoints[j].Subject
+	})
+
+	return aggregated, nil
+}
+
+// outputStats outputs the aggregated stats
+func outputStats(stats *AggregatedStats, format string) error {
+	switch strings.ToLower(format) {
+	case "json":
+		data, err := json.MarshalIndent(stats, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+
+	case "yaml":
+		fmt.Printf("serviceName: %s\n", stats.ServiceName)
+		fmt.Printf("instanceCount: %d\n", stats.InstanceCount)
+		fmt.Println("instances:")
+		for _, inst := range stats.Instances {
+			fmt.Printf("  - instanceId: %s\n", inst.InstanceId)
+			fmt.Printf("    uptime: %s\n", inst.Uptime)
+			if len(inst.Endpoints) > 0 {
+				fmt.Println("    endpoints:")
+				for _, ep := range inst.Endpoints {
+					fmt.Printf("      - subject: %s\n", ep.Subject)
+					fmt.Printf("        success: %d\n", ep.Success)
+					fmt.Printf("        failures: %d\n", ep.Failures)
+					fmt.Printf("        latency:\n")
+					fmt.Printf("          avgMs: %.2f\n", ep.Latency.Avg)
+					fmt.Printf("          p95Ms: %.2f\n", ep.Latency.P95)
+				}
+			}
+		}
+		fmt.Println("aggregatedEndpoints:")
+		for _, ep := range stats.AggregatedEndpoints {
+			fmt.Printf("  - subject: %s\n", ep.Subject)
+			fmt.Printf("    totalSuccess: %d\n", ep.TotalSuccess)
+			fmt.Printf("    totalFailures: %d\n", ep.TotalFailures)
+			fmt.Printf("    avgLatencyMs: %.2f\n", ep.AvgLatencyMs)
+			fmt.Printf("    p95RangeMs: %s\n", ep.P95Range)
+		}
+
+	case "table":
+		fmt.Printf("Service: %s\n", stats.ServiceName)
+		fmt.Printf("Instances: %d\n\n", stats.InstanceCount)
+
+		// Instance summary
+		fmt.Println("INSTANCES:")
+		fmt.Printf("%-30s %-20s\n", "INSTANCE ID", "UPTIME")
+		fmt.Printf("%-30s %-20s\n", strings.Repeat("-", 30), strings.Repeat("-", 20))
+		for _, inst := range stats.Instances {
+			fmt.Printf("%-30s %-20s\n", truncateString(inst.InstanceId, 30), inst.Uptime)
+		}
+		fmt.Println()
+
+		// Aggregated endpoint stats
+		fmt.Println("AGGREGATED ENDPOINT STATS:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(w, "ENDPOINT\tSUCCESS\tFAILURES\tAVG(ms)\tMIN(ms)\tMAX(ms)\tP95 RANGE(ms)\n")
+		fmt.Fprintf(w, "--------\t-------\t--------\t-------\t-------\t-------\t-------------\n")
+		for _, ep := range stats.AggregatedEndpoints {
+			fmt.Fprintf(w, "%s\t%d\t%d\t%.2f\t%.2f\t%.2f\t%s\n",
+				ep.Subject, ep.TotalSuccess, ep.TotalFailures,
+				ep.AvgLatencyMs, ep.MinLatencyMs, ep.MaxLatencyMs, ep.P95Range)
+		}
+		w.Flush()
+
+	default:
+		return fmt.Errorf("unknown format: %s (supported: table, json, yaml)", format)
+	}
+	return nil
 }
 
 // outputServiceList outputs the list of discovered services

--- a/pkg/nats-service/discovery.go
+++ b/pkg/nats-service/discovery.go
@@ -14,6 +14,9 @@ const DiscoverySubject = "_discovery.all"
 // ApiDocsSubjectSuffix is the suffix for the API documentation subject
 const ApiDocsSubjectSuffix = "_api_docs"
 
+// StatsSubjectSuffix is the suffix for the stats endpoint (no queue group - all instances respond)
+const StatsSubjectSuffix = "_stats"
+
 // ServiceInfo represents the basic service information returned by discovery
 type ServiceInfo struct {
 	ServiceName    string `json:"serviceName"`
@@ -39,6 +42,16 @@ type DiscoveryResponse struct {
 	ServiceName string        `json:"serviceName"`
 	BasePath    string        `json:"basePath"`
 	Endpoints   []EndpointDoc `json:"endpoints"`
+}
+
+// InstanceStatsResponse represents stats from a single service instance
+// This is returned by the _stats endpoint (broadcast to all instances)
+type InstanceStatsResponse struct {
+	ServiceName   string                  `json:"serviceName"`
+	InstanceId    string                  `json:"instanceId"`
+	SubjectPrefix string                  `json:"subjectPrefix"`
+	Uptime        string                  `json:"uptime"`
+	Endpoints     []EndpointStatsSnapshot `json:"endpoints"`
 }
 
 // HeaderDoc represents documentation for a single header
@@ -292,6 +305,75 @@ func (ns *NatService) drainDiscoverySubscription() error {
 	if ns.discoverySubscription != nil {
 		if err := ns.discoverySubscription.Drain(); err != nil {
 			log.Printf("Error draining discovery subscription: %v", err)
+			return err
+		}
+	}
+	return nil
+}
+
+// registerStatsEndpoint subscribes to the stats subject WITHOUT a queue group.
+// This means ALL instances will respond to stats requests, enabling aggregation.
+func (ns *NatService) registerStatsEndpoint() {
+	statsSubject := ns.basePath + "." + StatsSubjectSuffix
+
+	// Subscribe WITHOUT queue group so ALL instances respond
+	sub, err := ns.nc.Subscribe(statsSubject, ns.handleStatsRequest)
+	if err != nil {
+		log.Printf("WARNING: Unable to subscribe to stats subject '%s': %v. Stats will not be available.", statsSubject, err)
+		return
+	}
+
+	if !sub.IsValid() {
+		log.Printf("WARNING: Stats subscription to '%s' is invalid. Stats will not be available.", statsSubject)
+		return
+	}
+
+	log.Printf("Registered stats endpoint on subject: %s (broadcast, no queue)", statsSubject)
+	ns.statsSubscription = sub
+}
+
+// handleStatsRequest responds to stats requests with this instance's statistics
+func (ns *NatService) handleStatsRequest(msg *nats.Msg) {
+	// Build stats for all endpoints
+	endpointStats := make([]EndpointStatsSnapshot, 0, len(ns.endpointStats))
+	for _, stats := range ns.endpointStats {
+		endpointStats = append(endpointStats, stats.GetStats())
+	}
+
+	response := InstanceStatsResponse{
+		ServiceName:   ns.basePath,
+		InstanceId:    ns.instanceId,
+		SubjectPrefix: ns.basePath,
+		Uptime:        ns.getUptime(),
+		Endpoints:     endpointStats,
+	}
+
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		log.Printf("Error marshaling stats response: %v", err)
+		return
+	}
+
+	if err := msg.Respond(jsonData); err != nil {
+		log.Printf("Error responding to stats request: %v", err)
+	}
+}
+
+// getOrCreateEndpointStats returns the stats tracker for an endpoint, creating it if needed
+func (ns *NatService) getOrCreateEndpointStats(path string) *EndPointStats {
+	if stats, ok := ns.endpointStats[path]; ok {
+		return stats
+	}
+	stats := NewEndPointStats(ns.basePath + "." + path)
+	ns.endpointStats[path] = stats
+	return stats
+}
+
+// drainStatsSubscription drains the stats subscription if it exists
+func (ns *NatService) drainStatsSubscription() error {
+	if ns.statsSubscription != nil {
+		if err := ns.statsSubscription.Drain(); err != nil {
+			log.Printf("Error draining stats subscription: %v", err)
 			return err
 		}
 	}

--- a/pkg/nats-service/endpoint-stats.go
+++ b/pkg/nats-service/endpoint-stats.go
@@ -1,30 +1,240 @@
 package nats_service
 
-import "sync/atomic"
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
 
+const (
+	// DefaultLatencyBufferSize is the number of latency samples to keep for percentile calculations
+	// This bounds memory usage while providing accurate recent percentiles
+	DefaultLatencyBufferSize = 10000
+)
+
+// EndPointStats tracks performance metrics for a single endpoint
 type EndPointStats struct {
 	// Number of requests successfully processed
 	success atomic.Int64
 	// Number of requests that failed
 	failures atomic.Int64
-	//pct 95
-	pct95 atomic.Int64
-	//pct 99
-	pct99 atomic.Int64
-	// Average Latency
-	averageLatency int64
-	//endpoint subject
+
+	// Latency tracking with bounded memory
+	latencyMu     sync.RWMutex
+	latencies     []int64 // circular buffer of latency samples (in microseconds)
+	latencyIndex  int     // next write position in circular buffer
+	latencyCount  int64   // total number of samples added (may exceed buffer size)
+	latencySum    int64   // running sum for average calculation
+	latencyMin    int64   // minimum latency observed
+	latencyMax    int64   // maximum latency observed
+	bufferSize    int     // size of the circular buffer
+	bufferWrapped bool    // true if buffer has wrapped around at least once
+
+	// Endpoint metadata
 	subject       string
-	startDateTime int64
+	startDateTime time.Time
 }
 
-// add a successful request to the stats
+// LatencyStats contains computed latency statistics
+type LatencyStats struct {
+	Count   int64   `json:"count"`             // Total number of requests
+	Min     float64 `json:"minMs"`             // Minimum latency in milliseconds
+	Max     float64 `json:"maxMs"`             // Maximum latency in milliseconds
+	Avg     float64 `json:"avgMs"`             // Average latency in milliseconds
+	P50     float64 `json:"p50Ms"`             // 50th percentile (median)
+	P65     float64 `json:"p65Ms"`             // 65th percentile
+	P75     float64 `json:"p75Ms"`             // 75th percentile
+	P85     float64 `json:"p85Ms"`             // 85th percentile
+	P95     float64 `json:"p95Ms"`             // 95th percentile
+	Samples int     `json:"samplesInWindow"`   // Number of samples in current window
+}
 
-func (s *EndPointStats) AddTransactionLatency(latency int64, success bool) {
+// EndpointStatsSnapshot contains a point-in-time snapshot of endpoint statistics
+type EndpointStatsSnapshot struct {
+	Subject   string       `json:"subject"`
+	Success   int64        `json:"success"`
+	Failures  int64        `json:"failures"`
+	Latency   LatencyStats `json:"latency"`
+	StartTime time.Time    `json:"startTime"`
+	Uptime    string       `json:"uptime"`
+}
+
+// NewEndPointStats creates a new endpoint stats tracker with the default buffer size
+func NewEndPointStats(subject string) *EndPointStats {
+	return NewEndPointStatsWithBufferSize(subject, DefaultLatencyBufferSize)
+}
+
+// NewEndPointStatsWithBufferSize creates a new endpoint stats tracker with a custom buffer size
+func NewEndPointStatsWithBufferSize(subject string, bufferSize int) *EndPointStats {
+	if bufferSize <= 0 {
+		bufferSize = DefaultLatencyBufferSize
+	}
+	return &EndPointStats{
+		subject:       subject,
+		startDateTime: time.Now(),
+		latencies:     make([]int64, bufferSize),
+		bufferSize:    bufferSize,
+		latencyMin:    -1, // -1 indicates no samples yet
+	}
+}
+
+// AddTransactionLatency records a transaction's latency and success/failure status
+// latency should be provided in microseconds for precision
+func (s *EndPointStats) AddTransactionLatency(latencyMicros int64, success bool) {
 	if success {
 		s.success.Add(1)
 	} else {
 		s.failures.Add(1)
 	}
-	//	average latency
+
+	s.latencyMu.Lock()
+	defer s.latencyMu.Unlock()
+
+	// Add to circular buffer
+	s.latencies[s.latencyIndex] = latencyMicros
+	s.latencyIndex = (s.latencyIndex + 1) % s.bufferSize
+	if s.latencyIndex == 0 && s.latencyCount >= int64(s.bufferSize) {
+		s.bufferWrapped = true
+	}
+	s.latencyCount++
+	s.latencySum += latencyMicros
+
+	// Update min/max
+	if s.latencyMin < 0 || latencyMicros < s.latencyMin {
+		s.latencyMin = latencyMicros
+	}
+	if latencyMicros > s.latencyMax {
+		s.latencyMax = latencyMicros
+	}
+}
+
+// AddTransactionLatencyDuration is a convenience method that accepts a time.Duration
+func (s *EndPointStats) AddTransactionLatencyDuration(latency time.Duration, success bool) {
+	s.AddTransactionLatency(latency.Microseconds(), success)
+}
+
+// GetStats returns a snapshot of current endpoint statistics
+func (s *EndPointStats) GetStats() EndpointStatsSnapshot {
+	s.latencyMu.RLock()
+	defer s.latencyMu.RUnlock()
+
+	snapshot := EndpointStatsSnapshot{
+		Subject:   s.subject,
+		Success:   s.success.Load(),
+		Failures:  s.failures.Load(),
+		StartTime: s.startDateTime,
+		Uptime:    time.Since(s.startDateTime).Round(time.Second).String(),
+	}
+
+	// Calculate latency stats
+	snapshot.Latency = s.calculateLatencyStatsLocked()
+
+	return snapshot
+}
+
+// GetLatencyStats returns only the latency statistics
+func (s *EndPointStats) GetLatencyStats() LatencyStats {
+	s.latencyMu.RLock()
+	defer s.latencyMu.RUnlock()
+	return s.calculateLatencyStatsLocked()
+}
+
+// calculateLatencyStatsLocked computes latency statistics from the buffer
+// Must be called with latencyMu held (at least RLock)
+func (s *EndPointStats) calculateLatencyStatsLocked() LatencyStats {
+	stats := LatencyStats{
+		Count: s.latencyCount,
+	}
+
+	if s.latencyCount == 0 {
+		return stats
+	}
+
+	// Determine how many samples are in the buffer
+	var sampleCount int
+	if s.bufferWrapped || s.latencyCount >= int64(s.bufferSize) {
+		sampleCount = s.bufferSize
+	} else {
+		sampleCount = int(s.latencyCount)
+	}
+	stats.Samples = sampleCount
+
+	// Convert min/max to milliseconds
+	stats.Min = float64(s.latencyMin) / 1000.0
+	stats.Max = float64(s.latencyMax) / 1000.0
+
+	// Calculate average from running sum
+	stats.Avg = float64(s.latencySum) / float64(s.latencyCount) / 1000.0
+
+	// Copy and sort samples for percentile calculation
+	samples := make([]int64, sampleCount)
+	if s.bufferWrapped || s.latencyCount >= int64(s.bufferSize) {
+		copy(samples, s.latencies)
+	} else {
+		copy(samples, s.latencies[:sampleCount])
+	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+
+	// Calculate percentiles
+	stats.P50 = float64(s.percentile(samples, 50)) / 1000.0
+	stats.P65 = float64(s.percentile(samples, 65)) / 1000.0
+	stats.P75 = float64(s.percentile(samples, 75)) / 1000.0
+	stats.P85 = float64(s.percentile(samples, 85)) / 1000.0
+	stats.P95 = float64(s.percentile(samples, 95)) / 1000.0
+
+	return stats
+}
+
+// percentile calculates the p-th percentile from a sorted slice
+func (s *EndPointStats) percentile(sorted []int64, p int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if len(sorted) == 1 {
+		return sorted[0]
+	}
+
+	// Use nearest-rank method
+	index := (p * len(sorted)) / 100
+	if index >= len(sorted) {
+		index = len(sorted) - 1
+	}
+	return sorted[index]
+}
+
+// Reset clears all statistics
+func (s *EndPointStats) Reset() {
+	s.success.Store(0)
+	s.failures.Store(0)
+
+	s.latencyMu.Lock()
+	defer s.latencyMu.Unlock()
+
+	s.latencyIndex = 0
+	s.latencyCount = 0
+	s.latencySum = 0
+	s.latencyMin = -1
+	s.latencyMax = 0
+	s.bufferWrapped = false
+	// Clear the buffer
+	for i := range s.latencies {
+		s.latencies[i] = 0
+	}
+	s.startDateTime = time.Now()
+}
+
+// GetSuccessCount returns the number of successful requests
+func (s *EndPointStats) GetSuccessCount() int64 {
+	return s.success.Load()
+}
+
+// GetFailureCount returns the number of failed requests
+func (s *EndPointStats) GetFailureCount() int64 {
+	return s.failures.Load()
+}
+
+// GetTotalCount returns the total number of requests (success + failures)
+func (s *EndPointStats) GetTotalCount() int64 {
+	return s.success.Load() + s.failures.Load()
 }

--- a/pkg/nats-service/endpoint-stats_test.go
+++ b/pkg/nats-service/endpoint-stats_test.go
@@ -1,0 +1,208 @@
+package nats_service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEndPointStats_BasicCounts(t *testing.T) {
+	stats := NewEndPointStats("test.endpoint")
+
+	// Add some successes and failures
+	stats.AddTransactionLatency(1000, true)  // 1ms success
+	stats.AddTransactionLatency(2000, true)  // 2ms success
+	stats.AddTransactionLatency(3000, false) // 3ms failure
+
+	if stats.GetSuccessCount() != 2 {
+		t.Errorf("expected 2 successes, got %d", stats.GetSuccessCount())
+	}
+	if stats.GetFailureCount() != 1 {
+		t.Errorf("expected 1 failure, got %d", stats.GetFailureCount())
+	}
+	if stats.GetTotalCount() != 3 {
+		t.Errorf("expected 3 total, got %d", stats.GetTotalCount())
+	}
+}
+
+func TestEndPointStats_LatencyMinMax(t *testing.T) {
+	stats := NewEndPointStats("test.endpoint")
+
+	// Add latencies: 1ms, 5ms, 10ms
+	stats.AddTransactionLatency(1000, true)  // 1ms
+	stats.AddTransactionLatency(5000, true)  // 5ms
+	stats.AddTransactionLatency(10000, true) // 10ms
+
+	latency := stats.GetLatencyStats()
+
+	if latency.Min != 1.0 {
+		t.Errorf("expected min 1.0ms, got %f", latency.Min)
+	}
+	if latency.Max != 10.0 {
+		t.Errorf("expected max 10.0ms, got %f", latency.Max)
+	}
+}
+
+func TestEndPointStats_LatencyAverage(t *testing.T) {
+	stats := NewEndPointStats("test.endpoint")
+
+	// Add latencies: 1ms, 2ms, 3ms -> avg = 2ms
+	stats.AddTransactionLatency(1000, true)
+	stats.AddTransactionLatency(2000, true)
+	stats.AddTransactionLatency(3000, true)
+
+	latency := stats.GetLatencyStats()
+
+	if latency.Avg != 2.0 {
+		t.Errorf("expected avg 2.0ms, got %f", latency.Avg)
+	}
+}
+
+func TestEndPointStats_Percentiles(t *testing.T) {
+	stats := NewEndPointStatsWithBufferSize("test.endpoint", 100)
+
+	// Add 100 samples: 1ms, 2ms, 3ms, ..., 100ms
+	for i := 1; i <= 100; i++ {
+		stats.AddTransactionLatency(int64(i*1000), true)
+	}
+
+	latency := stats.GetLatencyStats()
+
+	// P50 should be around 50ms
+	if latency.P50 < 49 || latency.P50 > 51 {
+		t.Errorf("expected P50 around 50ms, got %f", latency.P50)
+	}
+
+	// P95 should be around 95ms
+	if latency.P95 < 94 || latency.P95 > 96 {
+		t.Errorf("expected P95 around 95ms, got %f", latency.P95)
+	}
+}
+
+func TestEndPointStats_CircularBuffer(t *testing.T) {
+	// Small buffer to test wrapping
+	stats := NewEndPointStatsWithBufferSize("test.endpoint", 10)
+
+	// Add 15 samples - buffer should wrap and only keep last 10
+	for i := 1; i <= 15; i++ {
+		stats.AddTransactionLatency(int64(i*1000), true)
+	}
+
+	latency := stats.GetLatencyStats()
+
+	// Count should be 15 (total added)
+	if latency.Count != 15 {
+		t.Errorf("expected count 15, got %d", latency.Count)
+	}
+
+	// Samples in window should be 10 (buffer size)
+	if latency.Samples != 10 {
+		t.Errorf("expected 10 samples in window, got %d", latency.Samples)
+	}
+
+	// Min should still track the overall min (1ms)
+	if latency.Min != 1.0 {
+		t.Errorf("expected min 1.0ms, got %f", latency.Min)
+	}
+
+	// Max should still track the overall max (15ms)
+	if latency.Max != 15.0 {
+		t.Errorf("expected max 15.0ms, got %f", latency.Max)
+	}
+}
+
+func TestEndPointStats_Duration(t *testing.T) {
+	stats := NewEndPointStats("test.endpoint")
+
+	// Test the duration convenience method
+	stats.AddTransactionLatencyDuration(5*time.Millisecond, true)
+
+	latency := stats.GetLatencyStats()
+
+	if latency.Min != 5.0 {
+		t.Errorf("expected min 5.0ms, got %f", latency.Min)
+	}
+}
+
+func TestEndPointStats_Reset(t *testing.T) {
+	stats := NewEndPointStats("test.endpoint")
+
+	stats.AddTransactionLatency(1000, true)
+	stats.AddTransactionLatency(2000, false)
+
+	stats.Reset()
+
+	if stats.GetSuccessCount() != 0 {
+		t.Errorf("expected 0 successes after reset, got %d", stats.GetSuccessCount())
+	}
+	if stats.GetFailureCount() != 0 {
+		t.Errorf("expected 0 failures after reset, got %d", stats.GetFailureCount())
+	}
+
+	latency := stats.GetLatencyStats()
+	if latency.Count != 0 {
+		t.Errorf("expected 0 count after reset, got %d", latency.Count)
+	}
+}
+
+func TestEndPointStats_Snapshot(t *testing.T) {
+	stats := NewEndPointStats("test.endpoint")
+
+	stats.AddTransactionLatency(5000, true)
+
+	snapshot := stats.GetStats()
+
+	if snapshot.Subject != "test.endpoint" {
+		t.Errorf("expected subject 'test.endpoint', got '%s'", snapshot.Subject)
+	}
+	if snapshot.Success != 1 {
+		t.Errorf("expected 1 success, got %d", snapshot.Success)
+	}
+	if snapshot.Latency.Count != 1 {
+		t.Errorf("expected latency count 1, got %d", snapshot.Latency.Count)
+	}
+	if snapshot.Uptime == "" {
+		t.Error("expected uptime to be set")
+	}
+}
+
+func TestEndPointStats_EmptyStats(t *testing.T) {
+	stats := NewEndPointStats("test.endpoint")
+
+	latency := stats.GetLatencyStats()
+
+	if latency.Count != 0 {
+		t.Errorf("expected count 0, got %d", latency.Count)
+	}
+	if latency.Min != 0 {
+		t.Errorf("expected min 0, got %f", latency.Min)
+	}
+	if latency.Max != 0 {
+		t.Errorf("expected max 0, got %f", latency.Max)
+	}
+	if latency.Avg != 0 {
+		t.Errorf("expected avg 0, got %f", latency.Avg)
+	}
+}
+
+func BenchmarkEndPointStats_AddLatency(b *testing.B) {
+	stats := NewEndPointStats("bench.endpoint")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		stats.AddTransactionLatency(int64(i%10000), true)
+	}
+}
+
+func BenchmarkEndPointStats_GetStats(b *testing.B) {
+	stats := NewEndPointStats("bench.endpoint")
+
+	// Pre-fill with samples
+	for i := 0; i < 10000; i++ {
+		stats.AddTransactionLatency(int64(i), true)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = stats.GetStats()
+	}
+}

--- a/pkg/nats-service/nats-service.go
+++ b/pkg/nats-service/nats-service.go
@@ -25,12 +25,16 @@ type NatService struct {
 	chunkedSubscription         *nats.Subscription
 	chunkedReceiverSubscription *nats.Subscription
 	discoverySubscription       *nats.Subscription
+	statsSubscription           *nats.Subscription
 	chunkCache                  *ttlcache.Cache[string, [][]byte]
 	endPoints                   []*NatsEndpoint
+	endpointStats               map[string]*EndPointStats // stats per endpoint path
 	basePath                    string
 	queueName                   string
 	description                 string
 	repositoryURL               string
+	instanceId                  string
+	startTime                   time.Time
 	maxRespSizeToCompress       int
 	maxRespSizeToChunk          int
 	debug                       bool
@@ -96,6 +100,16 @@ func (ns *NatService) SetRepositoryURL(url string) {
 	ns.repositoryURL = url
 }
 
+// GetInstanceId returns the unique identifier for this service instance
+func (ns *NatService) GetInstanceId() string {
+	return ns.instanceId
+}
+
+// getUptime returns the service uptime as a human-readable string
+func (ns *NatService) getUptime() string {
+	return time.Since(ns.startTime).Round(time.Second).String()
+}
+
 func NewLowLevel(basePath, natsQueueName, natsUrl, natsToken, natsKey string, maxRespSizeToCompress, maxRespSizeToChunk int) (*NatService, error) {
 	natsDebug := os.Getenv("NATS_DEBUG")
 
@@ -118,6 +132,11 @@ func NewLowLevelDebug(basePath, natsQueueName, natsUrl, natsToken, natsKey strin
 	}
 	log.Printf("Connected to NATS server at %s", natsUrl)
 
+	// Generate instance ID: hostname-shortUUID
+	hostname, _ := os.Hostname()
+	shortId := uuid.New().String()[:8]
+	instanceId := fmt.Sprintf("%s-%s", hostname, shortId)
+
 	ns := NatService{
 		url:                   natsUrl,
 		nc:                    nc,
@@ -126,6 +145,9 @@ func NewLowLevelDebug(basePath, natsQueueName, natsUrl, natsToken, natsKey strin
 		maxRespSizeToCompress: maxRespSizeToCompress,
 		maxRespSizeToChunk:    maxRespSizeToChunk,
 		chunkCache:            ttlcache.New[string, [][]byte](),
+		endpointStats:         make(map[string]*EndPointStats),
+		instanceId:            instanceId,
+		startTime:             time.Now(),
 		debug:                 debug,
 	}
 
@@ -320,6 +342,9 @@ func (ns *NatService) Start() error {
 	// Register discovery endpoint (non-blocking, graceful degradation on failure)
 	ns.registerDiscoveryEndpoint()
 
+	// Register stats endpoint (broadcast, no queue group - all instances respond)
+	ns.registerStatsEndpoint()
+
 	return nil
 }
 
@@ -428,6 +453,10 @@ func (ns *NatService) handleEndpointCall(endPoint *NatsEndpoint, msg *nats.Msg) 
 	if errResponding != nil {
 		natsMessage.Logger.Printf("error returning response: %v", errResponding)
 	}
+
+	// Track endpoint stats
+	stats := ns.getOrCreateEndpointStats(endPoint.path)
+	stats.AddTransactionLatency(elapsedTime, err == nil)
 
 	if ns.debug {
 		natsMessage.Logger.Printf("apiStatus: %s, user:%s latency: %dμs, sub: %s, req:%s, resp: %s", status, natsMessage.UserId, elapsedTime, msg.Subject, reqMsgLog, responseMsgLog)


### PR DESCRIPTION
## Summary
- Add endpoint latency tracking with bounded memory (circular buffer of 10K samples)
- Add `_stats` broadcast endpoint (no queue group) so ALL instances respond
- Add `--stats` flag to nats-discover CLI with client-side aggregation
- Add coding agent prompt for complete service documentation

## Features
- Track success/failure counts, min/max/avg latency (all-time)
- Calculate percentiles (p50, p65, p75, p85, p95) from recent samples
- Instance ID: `hostname-uuid8` for fail-proof unique identification
- Memory usage: ~80KB per endpoint (150 endpoints = ~12MB)
- Zero samples handled safely (no panics)

## Test plan
- [x] Unit tests for EndPointStats (9 tests)
- [x] Integration tests with NATS server
- [x] Zero samples edge case verified
- [x] Manual testing in development

🤖 Generated with [Claude Code](https://claude.com/claude-code)