### PR TITLE
Merge Development into Production: request-side chunking

### DIFF
--- a/pkg/nats-service-client/nats-service-client.go
+++ b/pkg/nats-service-client/nats-service-client.go
@@ -170,6 +170,19 @@ func (cl *Client) DoRequest(correlationId, subject string, header Header, data [
 
 	logger := log.New(os.Stdout, correlationId+" - ", log.Ltime|log.Ldate|log.Lshortfile|log.Lmsgprefix)
 	startTime := time.Now().UnixMicro()
+
+	// If data exceeds chunk threshold, serve chunks via a temporary subscription
+	var chunkSub *nats.Subscription
+	if len(data) > cl.maxSizeBeforeChunk {
+		var err error
+		chunkSub, err = cl.setupRequestChunkServing(data, &requestMsg, logger)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to setup request chunk serving: %w", err)
+		}
+		defer chunkSub.Unsubscribe()
+		data = nil // chunk metadata is in headers; no data in the main request
+	}
+
 	var reqErr error
 	var msg *nats.Msg
 
@@ -322,6 +335,57 @@ func convertNatsHeaderToHeader(header nats.Header) Header {
 	}
 
 	return nil
+}
+
+// setupRequestChunkServing splits data into chunks, subscribes to a temporary
+// subject to serve chunk download requests, and sets the chunk metadata headers
+// on the outgoing request message. The caller must defer Unsubscribe on the
+// returned subscription.
+func (cl *Client) setupRequestChunkServing(data []byte, requestMsg *nats.Msg, logger *log.Logger) (*nats.Subscription, error) {
+	chunks := nats_service_common.ChunkByteArray(data, cl.maxSizeBeforeChunk)
+	chunksId := uuid.New().String()
+	chunkSubject := nats.NewInbox()
+
+	sub, err := cl.nc.Subscribe(chunkSubject, func(msg *nats.Msg) {
+		indexStr := ""
+		if msg.Header != nil {
+			indexStr = msg.Header.Get(nats_service_common.CHUNK_INDEX)
+		}
+		index, err := strconv.Atoi(indexStr)
+		if err != nil || index < 0 || index >= len(chunks) {
+			resp := nats.Msg{Header: nats.Header{}}
+			resp.Header.Set(nats_service_common.STATUS, "400")
+			natsErr := nats_service.NatsServiceError{
+				Status:       400,
+				ErrorMessage: fmt.Sprintf("invalid chunk index: %s", indexStr),
+			}
+			resp.Data, _ = json.Marshal(natsErr)
+			msg.RespondMsg(&resp)
+			return
+		}
+		if cl.debug {
+			logger.Printf("Serving request chunk %d/%d", index+1, len(chunks))
+		}
+		resp := nats.Msg{
+			Data:   chunks[index],
+			Header: nats.Header{},
+		}
+		resp.Header.Set(nats_service_common.STATUS, "200")
+		msg.RespondMsg(&resp)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	requestMsg.Header.Set(nats_service_common.CHUNKED_SUBJECT, chunkSubject)
+	requestMsg.Header.Set(nats_service_common.CHUNKED_LENGTH, strconv.Itoa(len(chunks)))
+	requestMsg.Header.Set(nats_service_common.CHUNKS_ID, chunksId)
+
+	if cl.debug {
+		logger.Printf("Request data chunked into %d chunks (chunkSubject: %s)", len(chunks), chunkSubject)
+	}
+
+	return sub, nil
 }
 
 func setupConnOptions(opts []nats.Option) []nats.Option {

--- a/pkg/nats-service/chunks-handling.go
+++ b/pkg/nats-service/chunks-handling.go
@@ -1,6 +1,7 @@
 package nats_service
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -202,4 +203,47 @@ func (ns *NatService) validateAndGetChunkRequestInfo(chunkReq *nats.Msg) (string
 
 	return chunkReq.Header.Get(nats_service_common.CHUNKS_ID), chunkIndex, createLogger(msgId), nil
 
+}
+
+// downloadRequestChunks downloads chunked request data from the client.
+// This mirrors the client-side downloadChunks but runs on the server to
+// reassemble chunked request payloads.
+func (ns *NatService) downloadRequestChunks(subject, messageId, chunksId, count string, logger *log.Logger) ([]byte, error) {
+	chunksCount, err := strconv.Atoi(count)
+	if err != nil {
+		logger.Printf("Error parsing request chunks count: %s", err)
+		return nil, err
+	}
+
+	buff := bytes.NewBuffer(nil)
+
+	for i := 0; i < chunksCount; i++ {
+		request := nats.Msg{
+			Subject: subject,
+			Header:  nats.Header{},
+		}
+
+		request.Header.Set(nats_service_common.CHUNKS_ID, chunksId)
+		request.Header.Set(nats_service_common.CHUNK_INDEX, strconv.Itoa(i))
+		request.Header.Set(nats_service_common.MESSAGE_ID, messageId)
+
+		msg, err := ns.nc.RequestMsg(&request, 30*time.Second)
+		if err != nil {
+			logger.Printf("Error downloading request chunk %d: %s", i, err)
+			return nil, err
+		}
+
+		if msg.Header.Get(nats_service_common.STATUS) == "200" {
+			buff.Write(msg.Data)
+		} else {
+			natsError := &NatsServiceError{}
+			parsError := json.Unmarshal(msg.Data, natsError)
+			if parsError != nil {
+				return nil, fmt.Errorf("invalid response from client chunk server: %s, %w", msg.Data, parsError)
+			}
+			return nil, fmt.Errorf("unable to retrieve request chunk %d: %v", i, natsError)
+		}
+	}
+
+	return buff.Bytes(), nil
 }

--- a/pkg/nats-service/integration_test.go
+++ b/pkg/nats-service/integration_test.go
@@ -635,6 +635,140 @@ func testApiDocsEndpoint(t *testing.T, nc *nats.Conn) {
 	}
 }
 
+// TestRequestChunking verifies that large request payloads are chunked by the client
+// and reassembled by the server before the handler sees them.
+func TestRequestChunking(t *testing.T) {
+	natsURL := os.Getenv("NATS_URL")
+	if natsURL == "" {
+		natsURL = "nats://localhost:4222"
+	}
+
+	queueName := os.Getenv("NATS_QUEUE_NAME")
+	if queueName == "" {
+		queueName = "testing-chunked-req"
+	}
+
+	// Use small thresholds so we trigger chunking without needing huge payloads.
+	// compress threshold: 512 bytes, chunk threshold: 1024 bytes
+	maxCompress := 512
+	maxChunk := 1024
+
+	natService, err := nats_service.NewLowLevelDebug("chunkreq.api", queueName, natsURL, "", "", maxCompress, 1024*300, true)
+	if err != nil {
+		t.Skipf("Skipping test as NATS is not available: %v", err)
+		return
+	}
+
+	// Echo handler: returns request body as-is so we can verify round-trip integrity
+	echoHandler := func(msg *nats_service.NatsMessage) *nats_service.NatsServiceError {
+		msg.Logger.Printf("echo handler received %d bytes", len(msg.Body))
+		msg.ResponseBody = msg.Body
+		return nil
+	}
+
+	err = natService.AddEndpoint("echo", echoHandler)
+	if err != nil {
+		t.Fatalf("Failed to add echo endpoint: %v", err)
+	}
+
+	err = natService.Start()
+	if err != nil {
+		t.Fatalf("Failed to start service: %v", err)
+	}
+	defer natService.Shutdown()
+
+	// Client with the same small chunk threshold
+	client, err := nats_service_client.NewLowLevelClientWithChunkingAndCompressionDebug(natsURL, maxCompress, maxChunk, "", "", true)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	t.Run("ChunkedRequestRoundTrip", func(t *testing.T) {
+		// Build a payload that exceeds the chunk threshold after compression.
+		// Random-ish data compresses poorly, so 4KB of this will stay above 1024 after gzip.
+		payload := make([]byte, 4096)
+		for i := range payload {
+			payload[i] = byte(i % 251) // prime modulus → low repetition → poor compression
+		}
+
+		response, natsError, err := client.DoRequest("", "chunkreq.api.echo", nil, payload, 10*time.Second)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		if natsError != nil {
+			t.Fatalf("Request returned NATS error: %v", natsError)
+		}
+		if response == nil {
+			t.Fatal("Response is nil")
+		}
+		if len(response.Data) != len(payload) {
+			t.Fatalf("Response length mismatch: got %d, want %d", len(response.Data), len(payload))
+		}
+		for i := range payload {
+			if response.Data[i] != payload[i] {
+				t.Fatalf("Response data mismatch at byte %d: got %d, want %d", i, response.Data[i], payload[i])
+			}
+		}
+	})
+
+	t.Run("SmallRequestNotChunked", func(t *testing.T) {
+		// A payload under the chunk threshold should still work normally
+		payload := []byte("hello, small request")
+
+		response, natsError, err := client.DoRequest("", "chunkreq.api.echo", nil, payload, 5*time.Second)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		if natsError != nil {
+			t.Fatalf("Request returned NATS error: %v", natsError)
+		}
+		if string(response.Data) != string(payload) {
+			t.Errorf("Expected %q, got %q", string(payload), string(response.Data))
+		}
+	})
+
+	t.Run("CompressedButNotChunked", func(t *testing.T) {
+		// Highly compressible data that exceeds compress threshold but compresses
+		// well below the chunk threshold → compression only, no chunking
+		payload := []byte(strings.Repeat("AAAA", 256)) // 1024 bytes, compresses to ~30 bytes
+
+		response, natsError, err := client.DoRequest("", "chunkreq.api.echo", nil, payload, 5*time.Second)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		if natsError != nil {
+			t.Fatalf("Request returned NATS error: %v", natsError)
+		}
+		if string(response.Data) != string(payload) {
+			t.Errorf("Response mismatch: got %d bytes, want %d bytes", len(response.Data), len(payload))
+		}
+	})
+
+	t.Run("LargeChunkedRequest", func(t *testing.T) {
+		// Larger payload → multiple chunks to verify multi-chunk reassembly
+		payload := make([]byte, 16384)
+		for i := range payload {
+			payload[i] = byte((i * 7) % 253)
+		}
+
+		response, natsError, err := client.DoRequest("", "chunkreq.api.echo", nil, payload, 15*time.Second)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		if natsError != nil {
+			t.Fatalf("Request returned NATS error: %v", natsError)
+		}
+		if len(response.Data) != len(payload) {
+			t.Fatalf("Response length mismatch: got %d, want %d", len(response.Data), len(payload))
+		}
+		for i := range payload {
+			if response.Data[i] != payload[i] {
+				t.Fatalf("Response data mismatch at byte %d", i)
+			}
+		}
+	})
+}
+
 // testReservedEndpointRejection verifies that users cannot register endpoints with reserved suffixes
 func testReservedEndpointRejection(t *testing.T, natsURL, queueName string) {
 	natService, err := nats_service.NewLowLevelDebug("reserved.test.api", queueName+"-reserved", natsURL, "", "", 1024*2, 1024*300, false)

--- a/pkg/nats-service/nats-service.go
+++ b/pkg/nats-service/nats-service.go
@@ -480,6 +480,20 @@ func (ns *NatService) createNatsMessageFromRequest(endpoint *NatsEndpoint, msg *
 		userId = ""
 		messageId = uuid.New().String()
 	}
+	// Check if request data was chunked - reassemble before decompression
+	if msg.Header != nil && msg.Header.Get(nats_service_common.CHUNKED_SUBJECT) != "" {
+		chunkSubject := msg.Header.Get(nats_service_common.CHUNKED_SUBJECT)
+		chunksId := msg.Header.Get(nats_service_common.CHUNKS_ID)
+		chunksCount := msg.Header.Get(nats_service_common.CHUNKED_LENGTH)
+		logger := createLogger(messageId)
+
+		assembledData, err := ns.downloadRequestChunks(chunkSubject, messageId, chunksId, chunksCount, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download request chunks: %w", err)
+		}
+		msg.Data = assembledData
+	}
+
 	if msg.Header != nil && msg.Header.Get(nats_service_common.COMPRESSED_HEADER) == nats_service_common.GZIP_COMPRESSION_TYPE {
 		bytes, err := nats_service_common.GUnzipBytes(msg.Data)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Add request-side chunking for large client payloads so requests exceeding NATS message size limits are automatically split and reassembled
- Client serves chunks via a temporary inbox subscription; server downloads and reassembles before processing
- Symmetric with existing response-side chunking: compress-then-chunk on send, reassemble-then-decompress on receive
- Includes integration tests covering chunked, compressed, and small request paths

## Test plan
- [x] All existing tests pass (32/32)
- [x] New `TestRequestChunking` covers 4 scenarios: chunked round-trip, small (no chunking), compressed-only, and large multi-chunk
- [ ] Verify in staging environment with real workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)