### PR TITLE
Skip replies for fire-and-forget NATS messages

### DIFF
--- a/pkg/nats-service/integration_test.go
+++ b/pkg/nats-service/integration_test.go
@@ -52,6 +52,15 @@ func TestNATSIntegration(t *testing.T) {
 		t.Fatalf("Failed to add getCompressedResponse endpoint: %v", err)
 	}
 
+	fireAndForgetHandled := make(chan struct{}, 1)
+	err = natService.AddEndpoint("collect", func(msg *nats_service.NatsMessage) *nats_service.NatsServiceError {
+		fireAndForgetHandled <- struct{}{}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to add collect endpoint: %v", err)
+	}
+
 	// Add parameterized endpoint
 	paramHandler := func(msg *nats_service.NatsMessage) *nats_service.NatsServiceError {
 		userID := msg.Parameters["userId"]
@@ -102,6 +111,31 @@ func TestNATSIntegration(t *testing.T) {
 	t.Run("TestParameterizedEndpoint", func(t *testing.T) {
 		testParameterizedEndpoint(t, natService, client)
 	})
+
+	t.Run("TestFireAndForgetViaPublish", func(t *testing.T) {
+		testFireAndForgetViaPublish(t, natsURL, fireAndForgetHandled)
+	})
+}
+
+func testFireAndForgetViaPublish(t *testing.T, natsURL string, handled <-chan struct{}) {
+	conn, err := nats.Connect(natsURL)
+	if err != nil {
+		t.Fatalf("failed to create publisher: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.Publish("rx.api.collect", []byte("event")); err != nil {
+		t.Fatalf("failed to publish fire-and-forget message: %v", err)
+	}
+	if err := conn.Flush(); err != nil {
+		t.Fatalf("failed to flush fire-and-forget message: %v", err)
+	}
+
+	select {
+	case <-handled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fire-and-forget endpoint was not handled")
+	}
 }
 
 func testGetTimeViaClient(t *testing.T, client *nats_service_client.Client) {

--- a/pkg/nats-service/nats-service.go
+++ b/pkg/nats-service/nats-service.go
@@ -574,6 +574,14 @@ func (ns *NatService) Shutdown() error {
 }
 
 func (ns *NatService) respondToRequest(req *nats.Msg, responseMsg *nats.Msg) error {
+	// NATS Publish/PublishMsg messages intentionally have no reply subject. They
+	// are fire-and-forget deliveries, so processing the endpoint is the complete
+	// operation and there is nowhere to send a response. Avoid calling
+	// RespondMsg in that case: NATS returns ErrMsgNoReply, which previously
+	// produced a misleading error log for every successfully processed event.
+	if req == nil || req.Reply == "" {
+		return nil
+	}
 
 	//if it is small enough, then we send it back
 	if len(responseMsg.Data) < ns.maxRespSizeToChunk {

--- a/pkg/nats-service/response_test.go
+++ b/pkg/nats-service/response_test.go
@@ -1,0 +1,32 @@
+package nats_service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestRespondToRequestSkipsFireAndForgetMessage(t *testing.T) {
+	service := &NatService{maxRespSizeToChunk: 1024}
+	request := &nats.Msg{}
+	response := &nats.Msg{Header: nats.Header{}, Data: []byte("processed")}
+
+	if err := service.respondToRequest(request, response); err != nil {
+		t.Fatalf("fire-and-forget message should not attempt a reply: %v", err)
+	}
+}
+
+func TestRespondToRequestPreservesRequestReplyPath(t *testing.T) {
+	service := &NatService{maxRespSizeToChunk: 1024}
+	request := &nats.Msg{Reply: "_INBOX.requester"}
+	response := &nats.Msg{Header: nats.Header{}, Data: []byte("processed")}
+
+	// The synthetic message is intentionally not bound to a subscription. A
+	// bound-message error proves a reply subject still follows the existing
+	// RespondMsg path instead of being treated as fire-and-forget.
+	err := service.respondToRequest(request, response)
+	if !errors.Is(err, nats.ErrMsgNotBound) {
+		t.Fatalf("request/reply message should attempt RespondMsg; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Treat NATS messages without a reply subject as fire-and-forget deliveries. The endpoint still processes the message and records its statistics, but the framework no longer attempts to send a response to a destination that does not exist.

This keeps the current request/reply and response-chunking behavior unchanged whenever NATS supplies a reply subject.

## Root cause

The service framework invokes endpoint handlers for both request/reply calls and ordinary `Publish`/`PublishMsg` deliveries. After a successful handler invocation, it previously called `RespondMsg` unconditionally.

Fire-and-forget messages intentionally have an empty `msg.Reply`. NATS therefore returned:

```
nats: message does not have a reply
```

The framework then logged that expected protocol condition as an application error:

```
error returning response: nats: message does not have a reply
```

During the eventsCollector incident investigation, more than 226,983 of these messages were observed in a short interval. This created substantial misleading log volume and avoidable logging/CPU/I/O pressure even though the underlying event handler had completed.

## Changes

- Return successfully from the response helper when the incoming message is nil or has no reply subject.
- Continue using the existing `RespondMsg` and chunked-response path when a reply subject exists.
- Add focused unit tests proving:
  - fire-and-forget messages skip the response operation;
  - request/reply messages still enter the existing response path.
- Add an integration test that publishes an event without a reply subject and verifies the endpoint processes it against a real NATS server.

## Operational impact

After services adopt this library version:

- successful fire-and-forget event handling will no longer emit `error returning response: nats: message does not have a reply`;
- the associated log amplification, log ingestion, and avoidable application I/O are removed;
- real response failures for request/reply calls remain visible;
- normal request/reply clients continue to receive the same responses, headers, compression, and chunking behavior as before.

This is a low-risk protocol correction: the framework checks the reply subject NATS already provides instead of changing endpoint business logic or delivery semantics.

## Limitations

This PR does **not** prove or repair the initiating cause of the observed eventsCollector task restarts. It removes a strongly correlated error-amplification mechanism.

It also does not eliminate legitimate client errors such as:

- `nats: no responders available for request` when no collector instance is subscribed;
- `nats: timeout` when a request/reply operation exceeds its timeout.

Those conditions require service availability, scaling, health/readiness, and backpressure work. Bounded endpoint concurrency is intentionally left for a separate change because it introduces capacity limits and overload behavior that need configuration and load testing.

## Validation

- `go test -mod=vendor ./...`
- Docker Compose full suite against a real NATS server: passed
  - existing request/reply integration cases passed;
  - new fire-and-forget publish integration case passed without the no-reply error.
- `go vet -mod=vendor ./pkg/nats-service`
- `go build -mod=vendor ./...`

The repository-wide `go vet -mod=vendor ./...` still reports an existing issue in `cmd/nats-service-example/main.go` about an unbuffered `os.Signal` channel. That file is unchanged by this PR.