### PR TITLE
Fix data race on the endpointStats map

### DIFF
--- a/pkg/nats-service/discovery.go
+++ b/pkg/nats-service/discovery.go
@@ -180,7 +180,6 @@ func (ns *NatService) handleApiDocsRequest(msg *NatsMessage) *NatsServiceError {
 	return nil
 }
 
-
 // buildEndpointDocs creates documentation for all registered endpoints
 func (ns *NatService) buildEndpointDocs() []EndpointDoc {
 	docs := make([]EndpointDoc, 0, len(ns.endPoints))
@@ -335,8 +334,14 @@ func (ns *NatService) registerStatsEndpoint() {
 // handleStatsRequest responds to stats requests with this instance's statistics
 func (ns *NatService) handleStatsRequest(msg *nats.Msg) {
 	// Build stats for all endpoints
-	endpointStats := make([]EndpointStatsSnapshot, 0, len(ns.endpointStats))
+	ns.endpointStatsMu.Lock()
+	trackers := make([]*EndPointStats, 0, len(ns.endpointStats))
 	for _, stats := range ns.endpointStats {
+		trackers = append(trackers, stats)
+	}
+	ns.endpointStatsMu.Unlock()
+	endpointStats := make([]EndpointStatsSnapshot, 0, len(trackers))
+	for _, stats := range trackers {
 		endpointStats = append(endpointStats, stats.GetStats())
 	}
 
@@ -359,8 +364,12 @@ func (ns *NatService) handleStatsRequest(msg *nats.Msg) {
 	}
 }
 
-// getOrCreateEndpointStats returns the stats tracker for an endpoint, creating it if needed
+// getOrCreateEndpointStats returns the stats tracker for an endpoint,
+// creating it if needed. Endpoint handlers run on concurrent goroutines, so
+// the map itself must be guarded (the tracker has its own internal locking).
 func (ns *NatService) getOrCreateEndpointStats(path string) *EndPointStats {
+	ns.endpointStatsMu.Lock()
+	defer ns.endpointStatsMu.Unlock()
 	if stats, ok := ns.endpointStats[path]; ok {
 		return stats
 	}

--- a/pkg/nats-service/nats-service.go
+++ b/pkg/nats-service/nats-service.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dlclark/regexp2"
@@ -29,6 +30,7 @@ type NatService struct {
 	chunkCache                  *ttlcache.Cache[string, [][]byte]
 	endPoints                   []*NatsEndpoint
 	endpointStats               map[string]*EndPointStats // stats per endpoint path
+	endpointStatsMu             sync.Mutex                // guards endpointStats (handlers run concurrently)
 	basePath                    string
 	queueName                   string
 	description                 string


### PR DESCRIPTION
## Problem

\`getOrCreateEndpointStats\` reads and writes \`ns.endpointStats\` with no lock, but it is called from \`handleEndpointCall\`, which \`Start\` runs on a **new goroutine per message**. Any service that handles more than one request races on this map — \`go test -race\` flags it deterministically (found by the nats-agent e2e suite), and Go maps can fatal with \`concurrent map read and map write\` under real concurrency. \`handleStatsRequest\` iterates the same map unguarded.

## Fix

A \`sync.Mutex\` on \`NatService\` guarding the map: lock around lookup-or-create, and snapshot the tracker pointers under the lock before building stats responses. The per-endpoint \`EndPointStats\` tracker already has its own internal locking, so only the map itself needed the guard.

## Verification

The nats-agent e2e suite (agents + tool hosts built on nats-service, embedded nats-server) fails \`-race\` on v1.4.45 and passes cleanly against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)