### PR TITLE
Add error handling to GUnzipBytes to prevent panics

### DIFF
--- a/pkg/nats-service-common/common.go
+++ b/pkg/nats-service-common/common.go
@@ -3,6 +3,7 @@ package nats_service_common
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"log"
 )
 
@@ -35,13 +36,18 @@ func GZipBytes(toBegzipped []byte) []byte {
 
 func GUnzipBytes(toUnzip []byte) ([]byte, error) {
 	b := bytes.NewBuffer(toUnzip)
-	var r *gzip.Reader
 
-	r, _ = gzip.NewReader(b)
+	r, err := gzip.NewReader(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+	}
 	defer r.Close()
 
 	var out bytes.Buffer
-	_, err := out.ReadFrom(r)
+	_, err = out.ReadFrom(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read gzip data: %w", err)
+	}
 	return out.Bytes(), err
 }
 


### PR DESCRIPTION
A message with nil data could cause a panic due to the absense of error handling, bringing whatever service was using this lib down with it.