### PR TITLE
Prevent nil pointer panic in GUnzipBytes on invalid gzip payloads

### DIFF
--- a/pkg/nats-service-common/common.go
+++ b/pkg/nats-service-common/common.go
@@ -3,6 +3,7 @@ package nats_service_common
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"log"
 )
 
@@ -35,13 +36,18 @@ func GZipBytes(toBegzipped []byte) []byte {
 
 func GUnzipBytes(toUnzip []byte) ([]byte, error) {
 	b := bytes.NewBuffer(toUnzip)
-	var r *gzip.Reader
 
-	r, _ = gzip.NewReader(b)
+	r, err := gzip.NewReader(b)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+	}
 	defer r.Close()
 
 	var out bytes.Buffer
-	_, err := out.ReadFrom(r)
+	_, err = out.ReadFrom(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read gzip data: %w", err)
+	}
 	return out.Bytes(), err
 }
 


### PR DESCRIPTION
## Summary

Hardens `GUnzipBytes` in `pkg/nats-service-common/common.go` against malformed or non-gzip payloads.

Previously the error from `gzip.NewReader` was discarded, leaving `r` nil on failure. The subsequent `defer r.Close()` and `out.ReadFrom(r)` then panicked with a nil pointer dereference. This surfaced when a request arrived with the gzip header set but a body that was not valid gzip — notably chunked requests from older client versions — taking down the service instead of returning an error.

## Changes

- Check and wrap the error from `gzip.NewReader`, returning early instead of proceeding with a nil reader.
- Check and wrap the error from `out.ReadFrom(r)` so truncated or corrupt streams return an error rather than partial data with no signal.

Both errors are wrapped with `%w` so callers can still inspect the underlying gzip error.

## Impact

No API change — the signature already returned an error; it just was not populated reliably. Callers that already check the error now get a descriptive failure instead of a process-level panic.
